### PR TITLE
Beautify Readme and add routes for blocking calls and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ using the API.
 You can set up the connection by creating new instance of `Domino`.
 
 
-> #### *class* Domino(project, api_key=None, host=None)
+> ### *class* Domino(project, api_key=None, host=None)
 
 The parameters are:
 
@@ -24,12 +24,12 @@ The parameters are:
 
 ## Methods
 
-> **runs_list**()
+> ### runs_list()
 
 List the runs on the selected project.
 
 
-> **runs_start**(command, isDirect, commitId, title, tier, publishApiEndpoint)
+> ### runs_start(*command, isDirect, commitId, title, tier, publishApiEndpoint*)
 
 Start a new run on the selected project. The parameters are:
 
@@ -41,27 +41,27 @@ Start a new run on the selected project. The parameters are:
 * *tier:* (Optional) The hardware tier to use for the run. Will use project default tier if not provided.
 * *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
 
-> **runs_stdout**(runId)
+> ### runs_stdout(*runId*)
 
 Get stdout emitted by a particular run.  The parameters are:
 
 * *runId:* string that identifies the run
 
-> **files_list**(commitId, path)
+> ### files_list(*commitId, path*)
 
 List the files in a folder in the Domino project. The parameters are:
 
 * *commitId:* The commitId to list files from.
 * *path:* (Defaults to "/") The path to list from.
 
-> **files_upload**(path, file)
+> ### files_upload(*path, file*)
 
 Upload a Python file object into the specified path inside the project. See `examples/upload_file.py` for an example. The parameters, both of which are required, are:
 
 * *path:* The path to save the file to. For example, `/README.md` will write to the root directory of the project while `/data/numbers.csv` will save the file to a subfolder named `data` (if the `data` folder does not yet exist, it will be created)
 * *file:* A Python file object. For example, `f = open("authors.txt","rb")`
 
-> **blobs_get**(key)
+> ### blobs_get(*key*)
 
 Retrieve a file from the Domino server by blob key. The parameters are:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ Start a new run on the selected project. The parameters are:
 * *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
 
 
+> ### runs_start_blocking(*command, isDirect, commitId, title, tier, publishApiEndpoint, poll_freq=5, max_poll_time=6000*)
+
+Same as method `run_start` except make a blocking request that waits until job is finished.
+
+* *command:* The command to run as an array of strings where members of the array represent arguments
+  of the command. E.g. `["main.py", "hi mom"]`
+* *isDirect:* (Optional) Whether or not this command should be passed directly to a shell.
+* *commitId:* (Optional) The commitId to launch from. If not provided, will launch from latest commit.
+* *title:* (Optional) A title for the run.
+* *tier:* (Optional) The hardware tier to use for the run. Will use project default tier if not provided.
+* *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
+* *poll_freq:* (Optional) Number of seconds in between polling of the Domino server for status of the task that is running.
+* *max_poll_time:* (Optional) Maximum number of seconds to wait for a task to complete.  If this threshold is exceeded, an exception is raised.
+
 > ### runs_stdout(*runId*)
 
 Get stdout emitted by a particular run.  The parameters are:

--- a/README.md
+++ b/README.md
@@ -7,49 +7,67 @@ using the API.
 
 ### Setting up the connection
 
-You can set up the connection by creating new instance of `Domino`. The parameters are:
+You can set up the connection by creating new instance of `Domino`.
 
-* project: A project identifier (in the form of ownerusername/projectname)
-* api_key: (Optional) An API key to authenticate with. If not provided the library will expect to find one
+
+> #### *class* Domino(project, api_key=None, host=None)
+
+The parameters are:
+
+* *project:* A project identifier (in the form of ownerusername/projectname)
+* *api_key:* (Optional) An API key to authenticate with. If not provided the library will expect to find one
   in the DOMINO_USER_API_KEY environment variable.
-* host: (Optional) A host URL. If not provided the library will expect to find one in the DOMINO_API_HOST
+* *host:* (Optional) A host URL. If not provided the library will expect to find one in the DOMINO_API_HOST
   environment variable.
 
-### Domino#runs_list
+---
+
+## Methods
+
+> **runs_list**()
 
 List the runs on the selected project.
 
-### Domino#runs_start
+
+> **runs_start**(command, isDirect, commitId, title, tier, publishApiEndpoint)
 
 Start a new run on the selected project. The parameters are:
 
-* command: The command to run as an array of strings where members of the array represent arguments
+* *command:* The command to run as an array of strings where members of the array represent arguments
   of the command. E.g. `["main.py", "hi mom"]`
-* isDirect: (Optional) Whether or not this command should be passed directly to a shell.
-* commitId: (Optional) The commitId to launch from. If not provided, will launch from latest commit.
-* title: (Optional) A title for the run.
-* tier: (Optional) The hardware tier to use for the run. Will use project default tier if not provided.
-* publishApiEndpoint: (Optional) Whether or not to publish an API endpoint from the resulting output.
+* *isDirect:* (Optional) Whether or not this command should be passed directly to a shell.
+* *commitId:* (Optional) The commitId to launch from. If not provided, will launch from latest commit.
+* *title:* (Optional) A title for the run.
+* *tier:* (Optional) The hardware tier to use for the run. Will use project default tier if not provided.
+* *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
 
-### Domino#files_list
+> **runs_stdout**(runId)
+
+Get stdout emitted by a particular run.  The parameters are:
+
+* *runId:* string that identifies the run
+
+> **files_list**(commitId, path)
 
 List the files in a folder in the Domino project. The parameters are:
 
-* commitId: The commitId to list files from.
-* path: (Defaults to "/") The path to list from.
+* *commitId:* The commitId to list files from.
+* *path:* (Defaults to "/") The path to list from.
 
-### Domino#files_upload
+> **files_upload**(path, file)
 
 Upload a Python file object into the specified path inside the project. See `examples/upload_file.py` for an example. The parameters, both of which are required, are:
 
-* path: The path to save the file to. For example, `/README.md` will write to the root directory of the project while `/data/numbers.csv` will save the file to a subfolder named `data` (if the `data` folder does not yet exist, it will be created)
-* file: A Python file object. For example, `f = open("authors.txt","rb")`
+* *path:* The path to save the file to. For example, `/README.md` will write to the root directory of the project while `/data/numbers.csv` will save the file to a subfolder named `data` (if the `data` folder does not yet exist, it will be created)
+* *file:* A Python file object. For example, `f = open("authors.txt","rb")`
 
-### Domino#blobs_get
+> **blobs_get**(key)
 
 Retrieve a file from the Domino server by blob key. The parameters are:
 
-* key: The key of the file to fetch from the blob server.
+* **key:** The key of the file to fetch from the blob server.
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The parameters are:
 
 ## Methods
 
+
 > ### runs_list()
 
 List the runs on the selected project.
@@ -41,11 +42,13 @@ Start a new run on the selected project. The parameters are:
 * *tier:* (Optional) The hardware tier to use for the run. Will use project default tier if not provided.
 * *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
 
+
 > ### runs_stdout(*runId*)
 
 Get stdout emitted by a particular run.  The parameters are:
 
 * *runId:* string that identifies the run
+
 
 > ### files_list(*commitId, path*)
 
@@ -54,12 +57,14 @@ List the files in a folder in the Domino project. The parameters are:
 * *commitId:* The commitId to list files from.
 * *path:* (Defaults to "/") The path to list from.
 
+
 > ### files_upload(*path, file*)
 
 Upload a Python file object into the specified path inside the project. See `examples/upload_file.py` for an example. The parameters, both of which are required, are:
 
 * *path:* The path to save the file to. For example, `/README.md` will write to the root directory of the project while `/data/numbers.csv` will save the file to a subfolder named `data` (if the `data` folder does not yet exist, it will be created)
 * *file:* A Python file object. For example, `f = open("authors.txt","rb")`
+
 
 > ### blobs_get(*key*)
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -70,13 +70,44 @@ class Domino:
         response = requests.post(url, auth=('', self._api_key), json=request)
         return response.json()
 
-
     def runs_start_blocking(self, command, isDirect=False, commitId=None, title=None,
                             tier=None, publishApiEndpoint=None, poll_freq=5,
                             max_poll_time=6000):
         """
         Run a tasks that runs in a blocking loop that periodically checks to
         see if the task is done.  If the task errors an exception is raised.
+
+        parameters
+        ----------
+        command : list of strings
+                  list that containst the name of the file to run in index 0 and
+                  args in subsequent positions.
+                  example:
+                  >> domino.runs_start(["main.py", "arg1", "arg2"])
+
+        isDirect : boolean (Optional)
+                   Whether or not this command should be passed directly to a shell.
+
+        commitId : string (Optional)
+                   The commitId to launch from. If not provided, will launch from latest commit.
+
+        title    : string (Optional)
+                   A title for the run
+
+        tier     : string (Optional)
+                   The hardware tier to use for the run. Will use project default
+                   tier if not provided.
+
+        publishApiEndpoint : boolean (Optional)
+                            Whether or not to publish an API endpoint from the resulting output.
+
+        poll_freq : int (Optional)
+                    Number of seconds in between polling of the Domino server for
+                    status of the task that is running.
+
+        max_poll_time : int (Optional)
+                        Maximum number of seconds to wait for a task to complete.
+                        If this threshold is exceeded, an exception is raised.
         """
         run_response = self.runs_start(command, isDirect, commitId, title,
                                        tier, publishApiEndpoint)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -42,7 +42,6 @@ class Domino:
         self._version = self.deployment_version().get("version")
         print(self._version)
 
-
     def _configure_logging(self):
         logging.basicConfig(level=logging.INFO)
         self._logger = logging.getLogger(__name__)
@@ -70,6 +69,18 @@ class Domino:
 
     def runs_status(self, runId):
         url = self._routes.runs_status(runId)
+        return self._get(url)
+
+    def runs_stdout(self, runId):
+        """
+        Get std out emitted by a particular run.
+
+        parameters
+        ----------
+        runId : string
+                the id associated with the run.
+        """
+        url = self._routes.runs_stdout(runId)
         return self._get(url)
 
     def files_list(self, commitId, path='/'):

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -21,6 +21,9 @@ class _Routes:
     def runs_status(self, runId):
         return self._build_project_url() + '/runs/' + runId
 
+    def runs_stdout(self, runId):
+        return self._build_project_url() + '/run/' + runId + '/stdout'
+
     def files_list(self, commitId, path):
         return self._build_project_url() + '/files/' + commitId + '/' + path
 


### PR DESCRIPTION
The purpose of this PR is to do the following:

- Beautify the readme file
- Add routes and methods for getting stdout of a run.  Need this functionality in order to integrate Domino with [Airflow](https://airflow.incubator.apache.org/)
- Added methods that make blocking calls and wait for the task to complete, and emit standard out.

cc: @johnjoo1 @ChuckRIHead