### PR TITLE
Fix version confusion

### DIFF
--- a/domino/__init__.py
+++ b/domino/__init__.py
@@ -1,3 +1,3 @@
 from .domino import Domino
 
-__version__ = "0.2.2"
+__version__ = "0.3.5"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,28 @@
 from distutils.core import setup
 
+## begin borrowed from https://github.com/pypa/pip/blob/master/setup.py#L11-L28
+import codecs
+import os
+import re
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+def read(*parts):
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+## end
+
 setup(
     name='python-domino',
-    version='0.3.4',
+    version=find_version("domino", "__init__.py"),
     author='Domino Data Lab',
     author_email='support@dominodatalab.com',
     packages=['domino'],


### PR DESCRIPTION
by consolidating where we keep the version information to just __init.py__ as suggested by https://packaging.python.org/guides/single-sourcing-package-version/

(relevant zendesk ticket #46637)