### PR TITLE
DOM-12518: update python client to account for new hardware tier argument for app publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,12 @@ Retrieve a file from the Domino server by blob key. The parameters are:
 
 <hr>
 
-### app_publish(*unpublishRunningApps=True*)
+### app_publish(*unpublishRunningApps=True*, *hardwareTierId=None*)
 
 Publishes an app in the Domino project, or republish an existing app. The parameters are:
 
-* *unpublishRunningApps:* (Defaults to True) Will check for any active app instances in the current project and unpublish them before publishing. 
+* *unpublishRunningApps:* (Defaults to True) Will check for any active app instances in the current project and unpublish them before publishing.
+* *hardwareTierId:* (Optional) Will launch the app on the specified hardware tier.
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Retrieve a file from the Domino server by blob key. The parameters are:
 Publishes an app in the Domino project, or republish an existing app. The parameters are:
 
 * *unpublishRunningApps:* (Defaults to True) Will check for any active app instances in the current project and unpublish them before publishing.
-* *hardwareTierId:* (Optional) Will launch the app on the specified hardware tier.
+* *hardwareTierId:* (Optional) Will launch the app on the specified hardware tier. Only applies for Domino 3.4+.
 
 <hr>
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -285,10 +285,7 @@ class Domino:
         if unpublishRunningApps is True:
             self.app_unpublish()
         url = self._routes.app_publish()
-        if hardwareTierId is None:
-            request = {"language": "App"}
-        else:
-            request = {"language": "App", "hardwareTierId": hardwareTierId}
+        request = {"language": "App", "hardwareTierId": hardwareTierId}
         response = requests.post(url, auth=('', self._api_key), json=request)
         return response
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -281,11 +281,14 @@ class Domino:
             return disposition
 
     # App functions
-    def app_publish(self, unpublishRunningApps=True):
+    def app_publish(self, unpublishRunningApps=True, hardwareTierId=None):
         if unpublishRunningApps is True:
             self.app_unpublish()
         url = self._routes.app_publish()
-        request = {"language": "App"}
+        if hardwareTierId is None:
+            request = {"language": "App"}
+        else:
+            request = {"language": "App", "hardwareTierId": hardwareTierId}
         response = requests.post(url, auth=('', self._api_key), json=request)
         return response
 


### PR DESCRIPTION
Updates `app_publish` to accept an optional `hardwareTierId` parameter which is introduced to the api in https://github.com/cerebrotech/domino/pull/14351.

See https://dominodatalab.atlassian.net/browse/DOM-12518 for more details. 