### PR TITLE
Fixed publish_ui() to use updated URL in Domino

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -381,6 +381,9 @@ class Domino:
     @property
     def _project_id(self):
         url = self._routes.publish_ui()
+        if self._version < "3.2.0":
+            url = self._routes.publish_ui_legacy()
+
         response = requests.get(url, auth=('', self._api_key))
         regex = re.compile("/models/create\\?projectId=(.{24,24})")
         matches = regex.findall(response.text)

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -89,7 +89,7 @@ class _Routes:
         return self._build_models_url() + '/' + model_id + '/versions'
 
     def publish_ui(self):
-        return self._build_project_url_private_api() + '/endpoints'
+        return self._build_project_url_private_api() + '/endpoints/modelManager'
 
     # Environment URLs
     def environments_list(self):

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -88,6 +88,9 @@ class _Routes:
     def model_version_publish(self, model_id):
         return self._build_models_url() + '/' + model_id + '/versions'
 
+    def publish_ui_legacy(self):
+        return self._build_project_url_private_api() + '/endpoints'
+
     def publish_ui(self):
         return self._build_project_url_private_api() + '/endpoints/modelManager'
 


### PR DESCRIPTION
The path /u/<user_name>/<project_name>/endpoints returns a 404 code now in newer versions of Domino. It seems we have internally updated the path to be /u/<user_name>/<project_name>/endpoints/modelManager, so publish_ui() function was updated to reflect the change. Without this fix, anything that relies on publish_ui() breaks. This particular code breaks:
https://github.com/dominodatalab/python-domino/blob/master/domino/domino.py#L380-L390