### PR TITLE
Airflow DominoOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,30 @@ Stops all running apps in the Domino project.
 
 <hr>
 
+## Airflow
+
+The `python-domino` client comes bundled with an Operator for use with airflow as an extra.
+
+To install it, add the `airflow` flag to extras with pip.
+
+```
+pip install -e git+git://github.com/dominodatalab/python-domino.git#egg=python-domino[airflow]
+```
+
+
+### DominoOperator
+
+```
+from domino.airflow import DominoOperator
+```
+
+**Note:** This is a `python>=3.5` feature due to `typing` support.
+
+Allows a user to schedule domino runs via airflow. Follows the same function signature as `runs_start` with two extra arguments:
+
+* `startup_delay: Optional[int] = 10` |  Add a startup delay to your job, useful if you want to delay execution until after other work finishes.
+* `include_setup_log: Optional[bool] = True` | Determine whether or not to publish the setup log of the job as the log prefix before `stdout`.
+
 ## License
 
 This library is made available under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Stops all running apps in the Domino project.
 
 The `python-domino` client comes bundled with an Operator for use with airflow as an extra.
 
-To install it, add the `airflow` flag to extras with pip.
+To install its dependencies, when installing the package from github add the `airflow` flag to extras with pip.
 
 ```
-pip install -e git+git://github.com/dominodatalab/python-domino.git#egg=python-domino[airflow]
+pip install -e git+https://github.com/dominodatalab/python-domino.git@master#egg=domino[airflow]
 ```
 
 

--- a/domino/airflow/__init__.py
+++ b/domino/airflow/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from domino.airflow._operator import DominoOperator
+except SyntaxError:
+    raise ImportError("Use of the Airflow DominoOperator requires typing (Python 3.5+).")

--- a/domino/airflow/_operator.py
+++ b/domino/airflow/_operator.py
@@ -1,0 +1,121 @@
+import time
+from typing import List, Optional, Any
+
+from bs4 import BeautifulSoup
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from domino import Domino
+
+
+class DominoOperator(BaseOperator):
+    """
+    Operator for interacting with Domino Data Lab
+    via the python-domino client library w/ some
+    additional functionality baked in. Follows the 
+    same run signature as domino.runs_start with
+    some extra arguments.
+    
+    Host and API key arguments are optional and can be
+    discovered via environment variable, as per the domino
+    python client.
+
+
+    Notes
+    ------
+    When combining `isDirect=True` with a command, you
+    need to pass in the entire command as a single string
+    in the command array. 
+    """
+
+    template_fields = ("command", "title")
+    ui_color = "#5188c7"
+
+    @apply_defaults
+    def __init__(
+        self,
+        project: str,
+        command: List[str],
+        host: Optional[str] = None,
+        api_key: Optional[str] = None,
+        domino_token_file: Optional[str] = None, 
+        isDirect: bool = None,
+        commitId: Optional[str] = None,
+        title: Optional[str] = None,
+        tier: Optional[str] = None,
+        publishApiEndpoint: Optional[bool] = None,
+        poll_freq: Optional[int] = 5,
+        max_poll_time: Optional[int] = 6000,
+        startup_delay: Optional[int] = 10,
+        include_setup_log: Optional[bool] = True,
+        *args,
+        **kwargs
+    ):
+        super(DominoOperator, self).__init__(*args, **kwargs)
+
+        self.log.info("Initializing Client...")
+        
+        self.project = project
+        self._api_key = api_key
+        self._host = host
+        self._domino_token_file = domino_token_file
+        self.command = command
+        self.is_direct = isDirect
+        self.commit_id = commitId
+        self.title = title
+        self.tier = tier
+        self.publish_api_endpoint = publishApiEndpoint
+        self.poll_freq = poll_freq
+        self.max_poll_time = max_poll_time
+        self.startup_delay = startup_delay
+        self.include_setup_log = include_setup_log
+
+        self.client = None
+        self.run_id = None
+
+    def execute(self, context: Any) -> dict:
+
+        self.client = Domino(self.project, self._api_key, self._host, self._domino_token_file)
+        self.log.info("Client Initialized for project: %s", self.project)
+
+        self.log.info("Starting run.")
+        if self.startup_delay:
+            time.sleep(self.startup_delay)
+
+        if self.is_direct:
+            if len(self.command) > 1:
+                raise ValueError(
+                    "Domino API will not accept a "
+                    "multipart command string this long if is_direct=True"
+                )
+
+        run_response = self.client.runs_start_blocking(
+            command=self.command,
+            isDirect=self.is_direct,
+            commitId=self.commit_id,
+            title=self.title,
+            tier=self.tier,
+            publishApiEndpoint=self.publish_api_endpoint,
+            poll_freq=self.poll_freq,
+            max_poll_time=self.max_poll_time
+        )
+        self.run_id = run_response["runId"]
+
+        log = self.client.get_run_log(self.run_id, self.include_setup_log)
+
+        # spool out and replay entire log
+        for line in log.splitlines():
+            if line:
+                # using bs4 to strip the HTML tags
+                text = BeautifulSoup(line).text
+                if "text-danger" in line:
+                    self.log.warning(text)
+                else:
+                    self.log.info(text)
+
+        return run_response
+
+    def on_kill(self) -> None:
+        if self.client is not None:
+            self.log.info('Stopping Domino Run')
+            self.client.run_stop(runId=self.run_id)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -199,6 +199,29 @@ class Domino:
         url = self._routes.runs_status(runId)
         return self._get(url)
 
+    def get_run_log(self, runId, includeSetupLog=True):
+        """
+        Get the unified log for a run (setup + stdout).
+
+        parameters
+        ----------
+        runId : string
+                the id associated with the run.
+        includeSetupLog : bool
+                whether or not to include the setup log in the output.
+        """
+
+        url = self._routes.runs_stdout(runId)
+
+        logs = list()
+
+        if includeSetupLog:
+            logs.append(self._get(url)["setup"])
+
+        logs.append(self._get(url)["stdout"])
+
+        return "\n".join(logs)
+        
     def get_run_info(self, run_id):
         for run_info in self.runs_list()['data']:
             if run_info['id'] == run_id:

--- a/examples/example_airflow_dag.py
+++ b/examples/example_airflow_dag.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.models import Variable
+
+from domino.airflow import DominoOperator
+
+api_key = Variable.get("DOMINO_API_KEY")
+host = Variable.get("DOMINO_API_HOST")
+
+default_args = {
+    "owner": "domino",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 6, 5),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=0.5),
+}
+
+dag = DAG(
+    "domino_pipeline",
+    description="Execute Airflow DAG in Domino",
+    default_args=default_args,
+    schedule_interval=timedelta(days=1),
+)
+
+t1 = DominoOperator(
+    task_id="hello_world",
+    api_key=api_key,
+    host=host,
+    project="weaton/domino-test",
+    isDirect=True,
+    dag=dag,
+    command=["python -V"],
+)
+

--- a/examples/example_airflow_dag.py
+++ b/examples/example_airflow_dag.py
@@ -4,7 +4,7 @@ from airflow.models import Variable
 
 from domino.airflow import DominoOperator
 
-api_key = Variable.get("DOMINO_API_KEY")
+api_key = Variable.get("DOMINO_USER_API_KEY")
 host = Variable.get("DOMINO_API_HOST")
 
 default_args = {

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,8 @@ setup(
     long_description='',
     install_requires=[
         'requests>=2.4.2'
-    ]
+    ],
+    extras_require={
+        "airflow":  ['apache-airflow==1.*,>=1.10', 'bs4==0.*,>=0.0.1'],
+    }
 )


### PR DESCRIPTION
Is there any interest in taking work that I've done to make a `DominoOperator` for airflow and bundling it with this project as an optional extra package? 

As a bonus side effect it could help greatly clean up the documentation in this section: https://docs.dominodatalab.com/en/4.1/reference/runs/advanced/Using_Apache_Airflow_with_Domino.html

The `PythonOperator` is recommended, but as an end user there are some pitfalls...

We use this internally for scheduling runs and it has some extra features to work around kinks of the API, mainly the fact that setup for runs isn't logged by default and functionality to help mitigate the race condition in 3.6 when scheduling multiple runs in parallel.

I would consider adding it to Airflow's operator contrib repository proper but I don't think there would be much community interest. Would be happy to submit the code to you guys here and let representatives from domino weigh-in and/or go through the Apache JIRA feature request process yourselves.

Some notes since this is WIP:
- Type hints would need to be made backwards compatible. (Unless we make this a Python3 only feature)
- Exception handling needs to be added if the associated extra dependencies aren't installed
- Documentation needs to be added, probably for just extra kwargs that don't follow the function signature of their wrapped counterparts

Thanks!