### PR TITLE
[DOM-20307][DOM-20308] Fix publish/un-publish App

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -287,15 +287,19 @@ class Domino:
     def app_publish(self, unpublishRunningApps=True, hardwareTierId=None):
         if unpublishRunningApps is True:
             self.app_unpublish()
-        url = self._routes.app_publish()
-        request = {"language": "App", "hardwareTierId": hardwareTierId}
+        app_id = self._app_id
+        url = self._routes.app_publish(app_id)
+        request = {
+            "hardwareTierId": hardwareTierId
+        }
         response = requests.post(url, auth=('', self._api_key), json=request)
         return response
 
     def app_unpublish(self):
-        apps = [r for r in self.runs_list()['data'] if r['notebookName'] == 'App' and r['isCompleted'] == False]
-        for app in apps:
-            self.run_stop(app['id'])
+        app_id = self._app_id
+        url = self._routes.app_unpublish(app_id)
+        response = requests.post(url, auth=('', self._api_key))
+        return response
 
     # Environment functions
     def environments_list(self):
@@ -388,6 +392,21 @@ class Domino:
         response = self._get(url)
         if key in response.keys():
             return response[key]
+
+    @property
+    def _app_id(self):
+        url = self._routes.app_list(self._project_id)
+        response = self._get(url)
+        if len(response) != 0:
+            app = response[0]
+        else:
+            raise Exception(f"No App found in project")
+        key = "id"
+        if key in app.keys():
+            app_id = app[key]
+        else:
+            app_id = None
+        return app_id
 
 
 def parse_play_flash_cookie(response):

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -100,10 +100,13 @@ class _Routes:
     def app_list(self, project_id):
         return self.host + f'/v4/modelProducts?projectId={project_id}'
 
-    def app_publish(self, app_id):
+    def app_create(self):
+        return self.host + '/v4/modelProducts'
+
+    def app_start(self, app_id):
         return self.host + f'/v4/modelProducts/{app_id}/start'
 
-    def app_unpublish(self, app_id):
+    def app_stop(self, app_id):
         return self.host + f'/v4/modelProducts/{app_id}/stop'
 
     # Find Project By OwnerName and project name Url

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -97,8 +97,14 @@ class _Routes:
         return self.host + '/version'
 
     # App URLs
-    def app_publish(self):
-        return self._build_project_url_private_api() + '/nb/startSession'
+    def app_list(self, project_id):
+        return self.host + f'/v4/modelProducts?projectId={project_id}'
+
+    def app_publish(self, app_id):
+        return self.host + f'/v4/modelProducts/{app_id}/start'
+
+    def app_unpublish(self, app_id):
+        return self.host + f'/v4/modelProducts/{app_id}/stop'
 
     # Find Project By OwnerName and project name Url
     def find_project_by_owner_name_and_project_name_url(self):


### PR DESCRIPTION
# Fix publish/un-publish App
These methods weren't working because of missing that endpoints

## Problem

*app_publish* : The route `/nb/startsession` called by this method was removed [here](https://github.com/cerebrotech/domino/pull/18039)

*app_unpublish*: The route `/run/stop` called by this method was removed.

## Solution
In this P.R I have replaced the above routes with these

*app_publish*: `POST https://{Host-Url}/v4/modelProducts/{app_id}/start`

*app_unpublish*: `POST https://{Host-Url}/v4/modelProducts/{app_id}/stop`

Note:
1. For retrieving the `app_id` used in above routes, I am using following endpoint
`GET https://{Host-Url}/v4/modelProducts?projectId={project_id}`

2. If app doesn't exists. The method will first try to create one. For this I am using following endpoint
`POST https://{Host-Url}/v4/modelProducts`

## Verified
Verified this on 4.2.0-SNAPSHOT, 4.1.9

## Links to Jira Ticket
[DOM-20307](https://dominodatalab.atlassian.net/browse/DOM-20307)
[DOM-20308](https://dominodatalab.atlassian.net/browse/DOM-20308)