### PR TITLE
[DOM-21559] Add `retry` param in `runs_start_blocking`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Same as method `run_start` except make a blocking request that waits until job i
 * *publishApiEndpoint:* (Optional) Whether or not to publish an API endpoint from the resulting output.
 * *poll_freq:* (Optional) Number of seconds in between polling of the Domino server for status of the task that is running.
 * *max_poll_time:* (Optional) Maximum number of seconds to wait for a task to complete.  If this threshold is exceeded, an exception is raised.
+* *retry_count:* (Optional) Maximum number of retry to do while polling (in-case of transient http errors). If this threshold is exceeded, an exception is raised.
 
 <hr>
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -137,6 +137,7 @@ class Domino:
         while True:
             try:
                 run_info = self.get_run_info(run_id)
+                current_retry_count = 0
             except requests.exceptions.RequestException as e:
                 current_retry_count += 1
                 self._logger.warn(f'Failed to get run info for runId: {run_id} : {e}')
@@ -144,6 +145,7 @@ class Domino:
                     raise Exception(f'Cannot get run info, max retry {retry_count} exceeded') from None
                 else:
                     self._logger.info(f'Retrying ({current_retry_count}/{retry_count}) getting run info ...')
+                    time.sleep(poll_freq)
                     continue
 
             elapsed_time = time.time() - poll_start

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -82,7 +82,7 @@ class Domino:
 
     def runs_start_blocking(self, command, isDirect=False, commitId=None,
                             title=None, tier=None, publishApiEndpoint=None,
-                            poll_freq=5, max_poll_time=6000):
+                            poll_freq=5, max_poll_time=6000, retry_count=5):
         """
         Run a tasks that runs in a blocking loop that periodically checks to
         see if the task is done.  If the task errors an exception is raised.
@@ -122,14 +122,30 @@ class Domino:
                         Maximum number of seconds to wait for a task to
                         complete. If this threshold is exceeded, an exception
                         is raised.
+
+        retry_count : int (Optional)
+                        Maximum number of retry to do while polling
+                        (in-case of transient httpd errors). If this
+                        threshold exceeds, an exception is raised.
         """
         run_response = self.runs_start(command, isDirect, commitId, title,
                                        tier, publishApiEndpoint)
         run_id = run_response['runId']
 
         poll_start = time.time()
+        current_retry_count = 0
         while True:
-            run_info = self.get_run_info(run_id)
+            try:
+                run_info = self.get_run_info(run_id)
+            except requests.exceptions.RequestException as e:
+                current_retry_count += 1
+                self._logger.warn(f'Failed to get run info for runId: {run_id} : {e}')
+                if current_retry_count > retry_count:
+                    raise Exception(f'Cannot get run info, max retry {retry_count} exceeded') from None
+                else:
+                    self._logger.info(f'Retrying ({current_retry_count}/{retry_count}) getting run info ...')
+                    continue
+
             elapsed_time = time.time() - poll_start
 
             if elapsed_time >= max_poll_time:

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -125,7 +125,7 @@ class Domino:
 
         retry_count : int (Optional)
                         Maximum number of retry to do while polling
-                        (in-case of transient httpd errors). If this
+                        (in-case of transient http errors). If this
                         threshold exceeds, an exception is raised.
         """
         run_response = self.runs_start(command, isDirect, commitId, title,


### PR DESCRIPTION
### What problem does this P.R solve?
Currently in `runs_start_blocking` method, if Http request fails because of transient http errors, the method fails. 

### Solution
This P.R adds a `retry` param, which will retry the request incase of transient http errors

### Link to Jira
https://dominodatalab.atlassian.net/browse/DOM-21559

![image](https://user-images.githubusercontent.com/21152367/85711650-1ac41900-b705-11ea-9992-a22181e77d46.png)
Case Method fails after Max retries
![image](https://user-images.githubusercontent.com/21152367/85712172-accc2180-b705-11ea-9e82-4e02205ae0fd.png)
Case Method succeeds after 2 failed request.
