### PR TITLE
DominoOperator logging fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ MANIFEST
 examples/results/
 *.pyc
 build/
+.venv
+.vscode

--- a/domino/airflow/_operator.py
+++ b/domino/airflow/_operator.py
@@ -21,7 +21,6 @@ class DominoOperator(BaseOperator):
     discovered via environment variable, as per the domino
     python client.
 
-
     Notes
     ------
     When combining `isDirect=True` with a command, you
@@ -90,8 +89,7 @@ class DominoOperator(BaseOperator):
                     "multipart command string this long if is_direct=True"
                 )
 
-        
-        self.client._logger.setLevel(logging.ERROR)
+        self.client.log.setLevel(logging.ERROR)
         run_response = self.client.runs_start_blocking(
             command=self.command,
             isDirect=self.is_direct,
@@ -102,7 +100,7 @@ class DominoOperator(BaseOperator):
             poll_freq=self.poll_freq,
             max_poll_time=self.max_poll_time
         )
-        self.client._logger.setLevel(logging.INFO)
+        self.client.log.setLevel(logging.INFO)
 
         self.run_id = run_response["runId"]
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -171,7 +171,7 @@ class Domino:
                                   .format(run_id))
                     raise Exception(header_msg + stdout_msg)
 
-                logging.info(stdout_msg)
+                self._logger.info(stdout_msg)
                 break
 
         return run_response

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -36,6 +36,14 @@ class Domino:
             self._logger.error(error_message)
             raise Exception(error_message)
 
+    @property
+    def log(self):
+        try:
+            return self._logger
+        except AttributeError:
+            self._configure_logging()
+            return self._logger
+
     def _configure_logging(self):
         logging.basicConfig(level=logging.INFO)
         self._logger = logging.getLogger(__name__)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,32 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from domino.airflow import DominoOperator
+
+TEST_PROJECT = os.environ.get("DOMINO_TEST_PROJECT")
+
+
+def test_my_operator():
+    """
+    To run this test you need to have at least configured airflow in
+    local mode and run:
+
+    `airflow initdb`
+    """
+    airflow = pytest.importorskip("airflow")
+
+    from airflow import DAG
+    from airflow.models import TaskInstance
+
+    dag = DAG(dag_id="foo", start_date=datetime.now())
+    task = DominoOperator(
+        dag=dag,
+        task_id="foo",
+        project=TEST_PROJECT,
+        isDirect=True,
+        command=["python -V"],
+    )
+    ti = TaskInstance(task=task, execution_date=datetime.now())
+    task.execute(ti.get_template_context())


### PR DESCRIPTION
Fixes #63 

Also adds some code to remove `bs4` related warnings by defaulting to the built in parser.