### PR TITLE
add hardwaretier validation; adjust run logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,142 @@ examples/results/
 build/
 .venv
 .vscode
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/domino/airflow/_operator.py
+++ b/domino/airflow/_operator.py
@@ -1,21 +1,19 @@
 import time
-import logging
 from typing import List, Optional, Any
 
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from domino import Domino
-from domino.exceptions import RunFailedException
 
 
 class DominoOperator(BaseOperator):
     """
     Operator for interacting with Domino Data Lab
     via the python-domino client library w/ some
-    additional functionality baked in. Follows the 
+    additional functionality baked in. Follows the
     same run signature as domino.runs_start with
     some extra arguments.
-    
+
     Host and API key arguments are optional and can be
     discovered via environment variable, as per the domino
     python client.
@@ -24,7 +22,7 @@ class DominoOperator(BaseOperator):
     ------
     When combining `isDirect=True` with a command, you
     need to pass in the entire command as a single string
-    in the command array. 
+    in the command array.
     """
 
     template_fields = ("command", "title")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -31,6 +31,7 @@ def test_operator():
     ti = TaskInstance(task=task, execution_date=datetime.now())
     task.execute(ti.get_template_context())
 
+
 def test_operator_fail(caplog):
     airflow = pytest.importorskip("airflow")
 
@@ -49,6 +50,7 @@ def test_operator_fail(caplog):
     
     with pytest.raises(Exception):
         task.execute(ti.get_template_context())
+
 
 def test_operator_fail_invalid_tier(caplog):
     airflow = pytest.importorskip("airflow")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,20 +1,20 @@
+"""
+To run these tests you need to have at least configured airflow in
+local mode and run:
+
+`airflow initdb`
+"""
 import os
 from datetime import datetime
 
 import pytest
-
+import logging
 from domino.airflow import DominoOperator
 
 TEST_PROJECT = os.environ.get("DOMINO_TEST_PROJECT")
 
 
-def test_my_operator():
-    """
-    To run this test you need to have at least configured airflow in
-    local mode and run:
-
-    `airflow initdb`
-    """
+def test_operator():
     airflow = pytest.importorskip("airflow")
 
     from airflow import DAG
@@ -30,3 +30,42 @@ def test_my_operator():
     )
     ti = TaskInstance(task=task, execution_date=datetime.now())
     task.execute(ti.get_template_context())
+
+def test_operator_fail(caplog):
+    airflow = pytest.importorskip("airflow")
+
+    from airflow import DAG
+    from airflow.models import TaskInstance
+
+    dag = DAG(dag_id="foo", start_date=datetime.now())
+    task = DominoOperator(
+        dag=dag,
+        task_id="foo",
+        project=TEST_PROJECT,
+        isDirect=True,
+        command=["python -c 'import sys; sys.exit(1)'"],
+    )
+    ti = TaskInstance(task=task, execution_date=datetime.now())
+    
+    with pytest.raises(Exception):
+        task.execute(ti.get_template_context())
+
+def test_operator_fail_invalid_tier(caplog):
+    airflow = pytest.importorskip("airflow")
+
+    from airflow import DAG
+    from airflow.models import TaskInstance
+
+    dag = DAG(dag_id="foo", start_date=datetime.now())
+    task = DominoOperator(
+        dag=dag,
+        task_id="foo",
+        project=TEST_PROJECT,
+        isDirect=True,
+        command=["python -V"],
+        tier='this tier does not exist',
+    )
+    ti = TaskInstance(task=task, execution_date=datetime.now())
+    
+    with pytest.raises(ValueError):
+        task.execute(ti.get_template_context())


### PR DESCRIPTION
fixes #67, updates logging in accordance with changes from #69.

The way that the `runs_start_blocking` method logs through the exception msg made it hard to catch and handle cleanly, instead I moved around the log processor from the Domino operator and re-factored it to use the new `.log` property which plays nice with airflow. 

Open to suggestions if you guys don't like this behavior, the cost of not fixing it is ugly formatting for logs on airflow job failure, since a pretty printed string is what is passed through the exception (which I then have to de-pretty print), I think ideally we'd get a raw log.