### PR TITLE
[DOM-23072] Add on demand spark cluster support to domino python package via v4 API to start job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the `python-domino` library will be documented in this fi
 
 ### Added
 
+* Add v4 API endpoint `job_start` to start job with `onDemandSparkCluster` option
+* Add v4 API endpoint `job_stop`, `job_status` & `job_start_blocking`
+
 ### Changed
 
 ## 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to the `python-domino` library will be documented in this fi
 
 ### Changed
 
+* Started caching project_id
+* Started using request session instead of creating new session every time
+
 ## 1.0.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,60 @@ Stops all running apps in the Domino project.
 
 <hr>
 
+### job_start(*command*, *commit_id=None*, *hardware_tier_name=None*, *environment_id=None*, *on_demand_spark_cluster_properties=None*):
+
+Starts a new Job (run) in the project
+
+* *command (string):* Command to execute in Job. Ex `domino.job_start(command="main.py arg1 arg2")`
+* *commit_id (string):* (Optional) The commitId to launch from. If not provided, will launch from latest commit.
+* *hardware_tier_name (string):* (Optional) The hardware tier NAME to launch job in. If not provided it will use the default hardware tier for the project
+* *environment_id (string):* (Optional) The environment id to launch job with. If not provided it will use the default environment for the project
+* *on_demand_spark_cluster_properties (dict):* (Optional) On demand spark cluster properties. Following properties
+                                                    can be provided in spark cluster
+                                                    
+    ```
+    {
+        "computeEnvironmentId": "<Environment ID configured with spark>"
+        "executorCount": "<Number of Executors in cluster>"
+         (optional defaults to 1)
+        "executorHardwareTierId": "<Hardware tier ID for Spark Executors>"
+         (optional defaults to last used historically if available)
+        "masterHardwareTierId":  "<Hardware tier ID for Spark master"
+         (optional defaults to last used historically if available)
+        "executorStorageMB": "<Executor's storage in MB>"
+         (optional defaults to 0; 1GB is 1000MB Here)
+    }
+    ```
+
+<hr>
+
+### job_stop(*job_id*, *commit_results=True*):
+
+Stops the Job (run) in the project
+
+* *job_id (string):* Job identifier
+* *commit_results (boolean):* Defaults to `True`, if `false` job results will not be committed 
+
+<hr>
+
+### job_status(*job_id*):
+
+Gets the status of a Job
+
+* *job_id (string):* Job identifier
+
+<hr>
+
+### job_start_blocking(*poll_freq=5*, *max_poll_time=6000*, **kwargs):
+
+Starts a job and polls until the job is finished. Additionally this method supports all the
+parameter in `job_start` method
+
+* *poll_freq:* Poll frequency interval in seconds
+* *max_poll_time:* Max poll time in seconds
+
+<hr>
+
 ## Airflow
 
 The `python-domino` client comes bundled with an Operator for use with airflow as an extra.

--- a/domino/constants.py
+++ b/domino/constants.py
@@ -1,8 +1,12 @@
 """
 Minimum Domino version supported by this python-domino library
 """
-
 MINIMUM_SUPPORTED_DOMINO_VERSION = '4.1.0'
+
+"""
+Minimum Domino version supporting on demand spark cluster
+"""
+MINIMUM_ON_DEMAND_SPARK_CLUSTER_SUPPORT_DOMINO_VERSION = '4.2.0'
 
 """
 Environment variable names used by this python-domino library

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -234,8 +234,8 @@ class Domino:
         # pprint.pformat outputs a string that is ready to be printed
         return pprint.pformat(self._get(url)['stdout'])
 
-    def job_start(self, command, commit_id=None, hardware_tier_name=None,
-                  environment_id=None, on_demand_spark_cluster_properties=None):
+    def job_start(self, command: str, commit_id: str = None, hardware_tier_name: str = None,
+                  environment_id: str = None, on_demand_spark_cluster_properties: dict = None) -> dict:
         """
         Starts a Domino Job via V4 API
         :param command:                             string
@@ -340,7 +340,7 @@ class Domino:
         response = self.request_manager.post(url, json=payload)
         return response.json()
 
-    def job_stop(self, job_id, commit_results=True):
+    def job_stop(self, job_id: str, commit_results: bool = True):
         """
         Stops the Job with given job_id
         :param job_id: The job identifier
@@ -355,7 +355,7 @@ class Domino:
         response = self.request_manager.post(url, json=request)
         return response
 
-    def job_status(self, job_id):
+    def job_status(self, job_id: str) -> dict:
         """
         Gets the status of job with given job_id
         :param job_id: The job identifier
@@ -365,7 +365,7 @@ class Domino:
             self._routes.job_status(job_id)
         ).json()
 
-    def job_start_blocking(self, poll_freq=5, max_poll_time=6000, **kwargs):
+    def job_start_blocking(self, poll_freq: int = 5, max_poll_time: int = 6000, **kwargs) -> dict:
         """
         Starts a job in a blocking loop, periodically polling for status of job
         is complete. Will ignore intermediate request exception.
@@ -376,7 +376,7 @@ class Domino:
         """
         def get_job_status(job_identifier):
             status = self.job_status(job_identifier)
-            self.log.info(f"Polling Job: {job_identifier} status is completed: ${status['statuses']['isCompleted']}")
+            self.log.info(f"Polling Job: {job_identifier} status is completed: {status['statuses']['isCompleted']}")
             return status
         job = self.job_start(**kwargs)
         job_id = job['id']

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -254,7 +254,7 @@ class Domino:
                                                     On demand spark cluster properties. Following properties
                                                     can be provided in spark cluster
                                                     {
-                                                        "computeEnvironmentId": "<Environment configured with spark>"
+                                                        "computeEnvironmentId": "<Environment ID configured with spark>"
                                                         "executorCount": "<Number of Executors in cluster>"
                                                          (optional defaults to 1)
                                                         "executorHardwareTierId": "<Hardware tier ID for Spark Executors>"

--- a/domino/exceptions.py
+++ b/domino/exceptions.py
@@ -2,10 +2,32 @@ class DominoException(Exception):
     """Base class for Domino Exceptions"""
     pass
 
+
 class RunNotFoundException(DominoException):
     """Run Not Found Exception"""
     pass
 
+
 class RunFailedException(DominoException):
     """Run Failed Exception"""
+    pass
+
+
+class EnvironmentNotFoundException(DominoException):
+    """Environment not found Exception"""
+    pass
+
+
+class HardwareTierNotFoundException(DominoException):
+    """Hardware tier not found Exception"""
+    pass
+
+
+class CommitNotFoundException(DominoException):
+    """Commit not found Exception"""
+    pass
+
+
+class OnDemandSparkClusterNotSupportedException(DominoException):
+    """On Demand Spark Cluster not supported"""
     pass

--- a/domino/helpers.py
+++ b/domino/helpers.py
@@ -14,6 +14,10 @@ def is_version_compatible(version: str) -> bool:
     return parse_version(version) >= parse_version(MINIMUM_SUPPORTED_DOMINO_VERSION)
 
 
+def is_on_demand_spark_cluster_supported(version: str) -> bool:
+    return parse_version(version) >= parse_version(MINIMUM_ON_DEMAND_SPARK_CLUSTER_SUPPORT_DOMINO_VERSION)
+
+
 def get_host_or_throw_exception(host):
     """
     Helper function to get `host` from passed variable or environment variable

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -12,18 +12,19 @@ class _HttpRequestManager:
     def __init__(self, auth: AuthBase):
         self.auth = auth
         self._logger = logging.getLogger(__name__)
+        self.request_session = requests.Session()
 
     def post(self, url, data=None, json=None, **kwargs):
-        return self._raise_for_status(requests.post(url, auth=self.auth, data=data, json=json, **kwargs))
+        return self._raise_for_status(self.request_session.post(url, auth=self.auth, data=data, json=json, **kwargs))
 
     def get(self, url, **kwargs):
-        return self._raise_for_status(requests.get(url, auth=self.auth, **kwargs))
+        return self._raise_for_status(self.request_session.get(url, auth=self.auth, **kwargs))
 
     def put(self, url, data=None, **kwargs):
-        return self._raise_for_status(requests.put(url, auth=self.auth, data=data, **kwargs))
+        return self._raise_for_status(self.request_session.put(url, auth=self.auth, data=data, **kwargs))
 
     def delete(self, url, **kwargs):
-        return self._raise_for_status(requests.delete(url, auth=self.auth, **kwargs))
+        return self._raise_for_status(self.request_session.delete(url, auth=self.auth, **kwargs))
 
     def get_raw(self, url):
         return self.get(url, stream=True).raw

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -103,6 +103,9 @@ class _Routes:
     def job_stop(self):
         return f'{self.host}/v4/jobs/stop'
 
+    def job_status(self, job_id):
+        return f'{self.host}/v4/jobs/{job_id}'
+
     def default_spark_setting(self, project_id):
         return f'{self.host}/v4/jobs/project/{project_id}/defaultSparkSettings'
 

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -97,8 +97,17 @@ class _Routes:
         return self.host + '/version'
 
     # Job URLs
+    def job_start(self):
+        return f'{self.host}/v4/jobs/start'
+
     def job_stop(self):
         return f'{self.host}/v4/jobs/stop'
+
+    def default_spark_setting(self, project_id):
+        return f'{self.host}/v4/jobs/project/{project_id}/defaultSparkSettings'
+
+    def useable_environments_list(self, project_id):
+        return f'{self.host}/v4/projects/{project_id}/useableEnvironments'
 
     # App URLs
     def app_list(self, project_id):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     long_description='',
     install_requires=[
         'requests>=2.4.2',
-        'bs4==0.*,>=0.0.1'
+        'bs4==0.*,>=0.0.1',
+        'polling2'
     ],
     extras_require={
         "airflow":  ['apache-airflow==1.*,>=1.10'],


### PR DESCRIPTION
This P.R adds following v4 API endpoints

```
 def job_start(self, command, commit_id=None, hardware_tier_name=None,
                  environment_id=None, on_demand_spark_cluster_properties=None):
 def job_stop(self, job_id, commit_results=True):
 def job_status(self, job_id):
 def job_start_blocking(self, poll_freq=5, max_poll_time=6000, **kwargs):
```

In this P.R i have added a new dependency `[polling2](https://pypi.org/project/polling2/)`, for blocking start job method.

### Linked issues
#70 

### References
https://dominodatalab.atlassian.net/browse/DOM-23072