### PR TITLE
Release `python-domino` 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to the `python-domino` library will be documented in this fi
 
 ### Added
 
-* `collaborators_remove` method added
+* `collaborators_remove` method
+* Model export and AWS SageMaker API integration
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to the `python-domino` library will be documented in this fi
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+## 1.0.4
+
+### Added
+
 * `collaborators_remove` method added
 
 ### Changed
+
 * Model version publish method (model_version_publish) doesn't take name anymore
 * `collaborators_add` method changed to use v4 API
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python bindings for the Domino API.
 
 Permits interaction with a Domino deployment from Python using the [Domino API](https://dominodatalab.github.io/api-docs/).
 
-The latest released version is [1.0.3](https://github.com/dominodatalab/python-domino/archive/1.0.3.zip).
+The latest released version is [1.0.4](https://github.com/dominodatalab/python-domino/archive/1.0.4.zip).
 
 ## Version Compatibility Matrix
 


### PR DESCRIPTION
Version from `_version.py` already bumped in [a previous PR](https://github.com/dominodatalab/python-domino/pull/85).