### PR TITLE
Fix syntax error in setup.py test_requires value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     tests_require = [
         'pytest==6.2.2',
-        'requests_mock~=1.9.*',
+        'requests_mock>=1.9.*',
     ],
     extras_require={
         "airflow":  ['apache-airflow==1.*,>=1.10'],


### PR DESCRIPTION
Version string in test_requires doesn't handle ~= operator.

This PR addresses issue #95.

Tested this works from a remote repo:

```
% pip install git+https://github.com/<gh_user>/python-domino.git@fix_setup_py_syntax#egg=python-domino
Looking in indexes: https://pypi.org/simple, https://ddl-pypi-reader:****@domino.jfrog.io/domino/api/pypi/pypi-local/simple
Obtaining python-domino from git+https://github.com/<gh_user>/python-domino.git#egg=python-domino
  Cloning https://github.com/<gh_user>/python-domino.git to ./fix_domino_setup/src/python-domino
  Running command git clone -q https://github.com/<gh_user>/python-domino.git /private/tmp/fix_domino_setup/src/python-domino
Collecting requests>=2.4.2
  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
Collecting bs4==0.*,>=0.0.1
  Using cached bs4-0.0.1-py3-none-any.whl
Collecting polling2
  Using cached polling2-0.4.6-py2.py3-none-any.whl (6.3 kB)
Collecting beautifulsoup4
  Using cached beautifulsoup4-4.9.3-py3-none-any.whl (115 kB)
Collecting idna<3,>=2.5
  Using cached idna-2.10-py2.py3-none-any.whl (58 kB)
Collecting chardet<5,>=3.0.2
  Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2021.5.30-py2.py3-none-any.whl (145 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.5-py2.py3-none-any.whl (138 kB)
Collecting soupsieve>1.2
  Using cached soupsieve-2.2.1-py3-none-any.whl (33 kB)
Installing collected packages: soupsieve, urllib3, idna, chardet, certifi, beautifulsoup4, requests, polling2, bs4, python-domino
  Running setup.py develop for python-domino
Successfully installed beautifulsoup4-4.9.3 bs4-0.0.1 certifi-2021.5.30 chardet-4.0.0 idna-2.10 polling2-0.4.6 python-domino-1.0.4 requests-2.25.1 soupsieve-2.2.1 urllib3-1.26.5
```