### PR TITLE
Move domino_is_reachable to helpers.py

### DIFF
--- a/domino/helpers.py
+++ b/domino/helpers.py
@@ -1,7 +1,10 @@
-from distutils.version import LooseVersion as parse_version
-from urllib import parse as url_parse
-from .constants import *
 import os
+import socket
+import urllib
+
+from distutils.version import LooseVersion as parse_version
+
+from .constants import *
 
 
 def is_version_compatible(version: str) -> bool:
@@ -76,5 +79,28 @@ def clean_host_url(host_url):
     Helper function to clean 'host_url'. This will extract
     hostname (with scheme) from the url
     """
-    url_split = url_parse.urlsplit(host_url)
+    url_split = urllib.parse.urlsplit(host_url)
     return f"{url_split.scheme}://{url_split.netloc}"
+
+
+def domino_is_reachable(url=os.getenv(DOMINO_HOST_KEY_NAME), port="443"):
+    """
+    Confirm that a deployment is accessible.
+
+    Returns Boolean value.
+    """
+    if url is None:
+        return False
+
+    fqdn = urllib.parse.urlsplit(url).netloc
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect((fqdn, int(port)))
+        is_reachable = True
+    except OSError:
+        print(f"{fqdn}:{port} is not reachable")
+        is_reachable = False
+    finally:
+        s.close()
+
+    return is_reachable

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -1,6 +1,4 @@
 import os
-import socket
-import urllib
 
 import requests
 import requests_mock
@@ -11,28 +9,8 @@ from domino.constants import (
     DOMINO_USER_API_KEY_KEY_NAME,
     DOMINO_TOKEN_FILE_KEY_NAME
 )
+from domino.helpers import domino_is_reachable
 from pytest import fixture, mark
-
-
-def domino_is_reachable(url=os.getenv(DOMINO_HOST_KEY_NAME), port="443"):
-    """
-    Confirm that a deployment is accessible for tests that require it.
-    """
-    if url is None:
-        return False
-
-    fqdn = urllib.parse.urlsplit(url).netloc
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.connect((fqdn, int(port)))
-        is_reachable = True
-    except OSError:
-        print(f"{fqdn}:{port} is not reachable")
-        is_reachable = False
-    finally:
-        s.close()
-
-    return is_reachable
 
 
 @fixture
@@ -132,7 +110,6 @@ def test_auth_against_real_deployment_with_api_key():
 def test_auth_against_real_deployment_with_token_file():
     """
     Confirm against a live system that validating by token file works.
-
     Assumes that ${DOMINO_API_HOST} contains a valid Domino URL
     Assumes that ${DOMINO_TOKEN_FILE} is a path to a file that contains a valid token
     """


### PR DESCRIPTION
This function was written as a helper in one test file, but it could
be generally imported and used by others if we move it to helpers.py.

Testing:

Unit tests that know about this function still pass after the move.

```
tests/test_basic_auth.py::test_object_creation_with_api_key PASSED
tests/test_basic_auth.py::test_object_creation_with_token_file PASSED
tests/test_basic_auth.py::test_auth_against_real_deployment_with_api_key PASSED
tests/test_basic_auth.py::test_auth_against_real_deployment_with_token_file PASSED
```