### PR TITLE
Permit customizing ignored exceptions when polling job status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the `python-domino` library will be documented in this fi
 
 ### Added
 
+* Added the ability to choose which exceptions to ignore (if any) while polling for `job_start_blocking`
+* Added several new unit tests in `test_basic_auth.py` and `test_jobs.py`
+
 ### Changed
 
 ## 1.0.4

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from requests import HTTPError
 
@@ -436,12 +436,15 @@ class Domino:
             self._routes.job_status(job_id)
         ).json()
 
-    def job_start_blocking(self, poll_freq: int = 5, max_poll_time: int = 6000, **kwargs) -> dict:
+    def job_start_blocking(self, poll_freq: int = 5, max_poll_time: int = 6000,
+                           ignore_exceptions: Tuple = (requests.exceptions.RequestException,),
+                           **kwargs) -> dict:
         """
         Starts a job in a blocking loop, periodically polling for status of job
         is complete. Will ignore intermediate request exception.
         :param poll_freq: int (Optional) polling frequency interval in seconds
         :param max_poll_time: int (Optional) max poll time in seconds
+        :param ignore_exceptions: tuple (Optional) a tuple of exceptions that can be ignored
         :param kwargs: Additional arguments to be passed to job_start
         :return:
         """
@@ -456,7 +459,7 @@ class Domino:
         job_status = polling2.poll(
             target=lambda: get_job_status(job_id),
             check_success=lambda status: status['statuses']['isCompleted'],
-            ignore_exceptions=(requests.exceptions.RequestException,),
+            ignore_exceptions=ignore_exceptions,
             timeout=max_poll_time,
             step=poll_freq,
             log_error=self.log.level

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+import requests_mock
+
+from domino.constants import DOMINO_TOKEN_FILE_KEY_NAME
+
+
+@pytest.fixture
+def mock_domino_version_response():
+    """
+    Simulate a valid response to an authenticated /version GET request.
+
+    Assumes the target endpoint is domino.somefakecompany.com/version.
+    """
+    version_info = {
+        "buildId": "12345",
+        "buildUrl": "https://server.somefakecompany.com/domino/12345",
+        "commitId": "123deadbeef456",
+        "commitUrl": "https://repo.somefakecompany.com/domino/commit/123deadbeef456",
+        "timestamp": "2021-06-14T16:50:02Z",
+        "version": "9.9.9"
+    }
+
+    dummy_url = "http://domino.somefakecompany.com"
+    with requests_mock.Mocker() as mock_endpoint:
+        response = mock_endpoint.get(f"{dummy_url}/version", json=version_info, status_code=200)
+        yield response
+
+
+@pytest.fixture
+def dummy_token_file(tmpdir):
+    """
+    Simulate a token file.
+    """
+    # Refer to https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmpdir-fixture for tmpdir usage
+    token_file = tmpdir.join("dummy_token_file.txt")
+    token_file.write("top_secret_auth_token")
+    return token_file
+
+
+@pytest.fixture
+def clear_env_for_api_key_test():
+    """
+    Unset any DOMINO_TOKEN_FILE var from the environment for API key tests.
+
+    If a token file is present in the environment, python-domino uses it preferentially,
+    which is mutually incompatible with testing the API key.
+    """
+    saved_environment = dict(os.environ)
+    os.environ.pop(DOMINO_TOKEN_FILE_KEY_NAME, default=None)
+    yield
+
+    # Restore original pre-test environment
+    os.environ.update(saved_environment)

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -1,7 +1,6 @@
 import os
 
 import requests
-import requests_mock
 
 from domino import Domino, bearer_auth
 from domino.constants import (
@@ -10,56 +9,7 @@ from domino.constants import (
     DOMINO_TOKEN_FILE_KEY_NAME
 )
 from domino.helpers import domino_is_reachable
-from pytest import fixture, mark
-
-
-@fixture
-def mock_domino_version_response():
-    """
-    Simulate a valid response to an authenticated /version GET request.
-
-    Assumes the target endpoint is domino.somefakecompany.com/version.
-    """
-    version_info = {
-        "buildId": "12345",
-        "buildUrl": "https://server.somefakecompany.com/domino/12345",
-        "commitId": "123deadbeef456",
-        "commitUrl": "https://repo.somefakecompany.com/domino/commit/123deadbeef456",
-        "timestamp": "2021-06-14T16:50:02Z",
-        "version": "9.9.9"
-    }
-
-    dummy_url = "http://domino.somefakecompany.com"
-    with requests_mock.Mocker() as mock_endpoint:
-        mock_endpoint.get(f"{dummy_url}/version", json=version_info, status_code=200)
-        yield
-
-
-@fixture
-def dummy_token_file(tmpdir):
-    """
-    Simulate a token file.
-    """
-    # Refer to https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmpdir-fixture for tmpdir usage
-    token_file = tmpdir.join("dummy_token_file.txt")
-    token_file.write("top_secret_auth_token")
-    return token_file
-
-
-@fixture
-def clear_env_for_api_key_test():
-    """
-    Unset any DOMINO_TOKEN_FILE var from the environment for API key tests.
-
-    If a token file is present in the environment, python-domino uses it preferentially,
-    which is mutually incompatible with testing the API key.
-    """
-    saved_environment = dict(os.environ)
-    os.environ.pop(DOMINO_TOKEN_FILE_KEY_NAME, default=None)
-    yield
-
-    # Restore original pre-test environment
-    os.environ.update(saved_environment)
+from pytest import mark
 
 
 @mark.usefixtures("mock_domino_version_response", "clear_env_for_api_key_test")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,82 @@
+import polling2
+import pytest
+
+from domino import Domino
+from requests.exceptions import RequestException
+
+
+@pytest.fixture
+def dummy_hostname():
+    return "http://domino.somefakecompany.com"
+
+
+@pytest.fixture
+def mock_job_start_blocking_setup(requests_mock, dummy_hostname):
+    """
+    Create mock replies to the chain of calls required before checking job status
+    """
+    # Mock the /version API endpoint (GET)
+    requests_mock.get(f"{dummy_hostname}/version", json={"version": "9.9.9"})
+
+    # Mock /findProjectByOwnerAndName API endpoint  (GET)
+    project_endpoint = "v4/gateway/projects/findProjectByOwnerAndName"
+    project_query = "ownerName=anyuser&projectName=anyproject"
+    requests_mock.get(f"{dummy_hostname}/{project_endpoint}?{project_query}", json={})
+
+    # Mock the jobs/start API endpoint (POST) and return run with ID 123
+    jobs_start_endpoint = "v4/jobs/start"
+    requests_mock.post(f"{dummy_hostname}/{jobs_start_endpoint}", json={"id": "123"})
+
+    # Mock STDOUT for run with ID 123
+    stdout_endpoint = "v1/projects/anyuser/anyproject/run/123/stdout"
+    requests_mock.get(f"{dummy_hostname}/{stdout_endpoint}", json={"stdout": "whatever"})
+
+    yield
+
+
+@pytest.mark.usefixtures("clear_env_for_api_key_test", "mock_job_start_blocking_setup")
+def test_job_status_completes_with_default_params(requests_mock, dummy_hostname):
+    """
+    Confirm that the happy path default case passes (no exceptions thrown)
+    """
+    # Mock a typical response from the jobs status API endpoint (GET)
+    jobs_status_endpoint = "v4/jobs/123"
+    requests_mock.get(f"{dummy_hostname}/{jobs_status_endpoint}",
+                      json={"statuses": {"isCompleted": True, "executionStatus": "whatever"}})
+
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+
+    job_status = d.job_start_blocking(command="foo.py", poll_freq=1, max_poll_time=1)
+    assert job_status['statuses']['isCompleted'] is True
+
+
+@pytest.mark.usefixtures("clear_env_for_api_key_test", "mock_job_start_blocking_setup")
+def test_job_status_ignores_RequestException_and_times_out(requests_mock, dummy_hostname):
+    """
+    Test that the default behavior is to simply ignore RequestException being thrown.
+    (In this case, timing out via polling2.TimeoutException is expected.)
+    """
+    # Force the jobs status API endpoint to throw a RequestException when called
+    jobs_status_endpoint = "v4/jobs/123"
+    requests_mock.get(f"{dummy_hostname}/{jobs_status_endpoint}", exc=RequestException)
+
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+
+    with pytest.raises(polling2.TimeoutException):
+        d.job_start_blocking(command="foo.py", poll_freq=1, max_poll_time=1)
+
+
+@pytest.mark.usefixtures("clear_env_for_api_key_test", "mock_job_start_blocking_setup")
+def test_job_status_without_ignoring_exceptions(requests_mock, dummy_hostname):
+    """
+    Test that ignore_exceptions can be overridden by passing in an empty tuple.
+    The call should fail immediately with RequestException.
+    """
+    # Force the jobs status API endpoint to throw a RequestException when called
+    jobs_status_endpoint = "v4/jobs/123"
+    requests_mock.get(f"{dummy_hostname}/{jobs_status_endpoint}", exc=RequestException)
+
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+
+    with pytest.raises(RequestException):
+        d.job_start_blocking(command="foo.py", ignore_exceptions=())


### PR DESCRIPTION
The actual code change here is very small -- the bulk of the changes
is new/edited test code.

Before this patch, starting a blocking job would ignore any HTTP
errors when checking for job status to complete, until polling finally
timed out. This change allows a user to specify which exceptions to
ignore by passing a tuple (which is the data type required by the
polling2 library) of ignored exceptions. Providing an empty tuple
means that no exceptions are ignored.

The original default behavior was not changed.

On the test side:

- a new unit test file was added: test_jobs.py
- fixtures were moved to a new conftest.py file to be more
  accessible across different tests

## Testing

New and previous unit tests are passing
```
cachedir: .pytest_cache
rootdir: /path/to/dominodatalab/python-domino, configfile: pytest.ini
plugins: requests-mock-1.9.3, anyio-3.1.0
collected 7 items

tests/test_basic_auth.py::test_object_creation_with_api_key PASSED
tests/test_basic_auth.py::test_object_creation_with_token_file PASSED
tests/test_basic_auth.py::test_auth_against_real_deployment_with_api_key PASSED
tests/test_basic_auth.py::test_auth_against_real_deployment_with_token_file PASSED
tests/test_jobs.py::test_job_status_completes_with_default_params PASSED
tests/test_jobs.py::test_job_status_ignores_RequestException_and_times_out PASSED
tests/test_jobs.py::test_job_status_without_ignoring_exceptions PASSED
```