### PR TITLE
Re-authentication capability to avoid reusing short-lived access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 * Added several new unit tests in `test_basic_auth.py` and `test_jobs.py`
 * Added a public method to re-authenticate if a token expires (assuming a long-running process)
 * Allow `auth_token` to be passed as a string to the `__init__()` method
+* Added re-authentication capability to avoid reusing short-lived access tokens
 
 ### Changed
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -39,8 +39,9 @@ class Domino:
         domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
         api_key = api_key or os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
 
-        # save token file to be able to re-authenticate automatically
+        self._api_key = api_key
         self._domino_token_file = domino_token_file
+        self._auth_token = auth_token
 
         # This call sets self.request_manager
         self.authenticate(api_key, auth_token, domino_token_file)
@@ -62,8 +63,9 @@ class Domino:
         """
         @functools.wraps(fn)
         def wrapper(self, *args, **kwargs):
-            if self._domino_token_file: # only token file is supported for re-authentication
-                self.authenticate(domino_token_file=self._domino_token_file)
+            self.authenticate(api_key=self._api_key,
+                              auth_token=self._auth_token,
+                              domino_token_file=self._domino_token_file)
             return fn(self, *args, **kwargs)
         return wrapper
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -60,6 +60,7 @@ class Domino:
         """
         Decorator for automatic re-authentication
         """
+        @functools.wraps(fn)
         def wrapper(self, *args, **kwargs):
             if self._domino_token_file: # only token file is supported for re-authentication
                 self.authenticate(domino_token_file=self._domino_token_file)


### PR DESCRIPTION
Domino's python wrapper has `BearerAuth` class which reads the token from file during instantiation, and then keeps reusing it for all the subsequent calls. This doesn't work well with short-lived access tokens provided by JWT credentials propagation, when the token expires. Since Domino 4.5.0, access tokens are short-lived (5 minutes) by default.

Adding a decorator function which will read access token before calling any public library method.

Testing by installing library in a Domino workspace:

```
ubuntu@run-613853f46db72615aac81bdc-hc6k4:/mnt$ python3
Python 3.8.10 (default, Jun  4 2021, 15:09:15)
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from domino import Domino
>>> domino = Domino('integration-test/quick-start', host='<host>')
INFO:domino.domino:Domino deployment <host> is running version 5.0.0
>>> import time
>>> time.sleep(360)
>>> domino.collaborators_get()
['integration-test']
>>>
```

After commenting out lines 64-65 in modifiied `domino.py` and installing library in a Domino workspace:

```
ubuntu@run-613853f46db72615aac81bdc-hc6k4:/mnt$ python3
Python 3.8.10 (default, Jun  4 2021, 15:09:15)
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from domino import Domino
>>> domino = Domino('integration-test/quick-start', host='<host>')
INFO:domino.domino:Domino deployment <host> is running version 5.0.0
>>> import time
>>> time.sleep(360)
>>> domino.collaborators_get()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/.local/lib/python3.8/site-packages/domino/domino.py", line 66, in wrapper
    return fn(self, *args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/domino/domino.py", line 576, in collaborators_get
    return self._get(url)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/domino/domino.py", line 880, in _get
    return self.request_manager.get(url).json()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/domino/http_request_manager.py", line 21, in get
    return self._raise_for_status(self.request_session.get(url, auth=self.auth, **kwargs))
  File "/home/ubuntu/.local/lib/python3.8/site-packages/domino/http_request_manager.py", line 34, in _raise_for_status
    response.raise_for_status()
  File "/opt/conda/lib/python3.8/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: <host>/integration-test/quick-start/collaborators
>>>
```
