### PR TITLE
Better error if auth token needs refresh when running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 * Automatically re-read auth token from file to avoid reusing short-lived access tokens
+* Better token expiration error handling for job_start and runs_start methods
 
 ### Changed
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -96,9 +96,11 @@ class Domino:
             "tier": tier,
             "publishApiEndpoint": publishApiEndpoint
         }
-
-        response = self.request_manager.post(url, json=request)
-        return response.json()
+        try:
+            response = self.request_manager.post(url, json=request)
+            return response.json()
+        except ReloginRequiredException:
+            self._logger.info(f" You need to log in to the Domino UI to start the run. Please do it at {self._routes.host}")
 
     def runs_start_blocking(self, command, isDirect=False, commitId=None,
                             title=None, tier=None, publishApiEndpoint=None,
@@ -420,8 +422,11 @@ class Domino:
           "computeClusterProperties": validated_compute_cluster_properties,
           "environmentId": environment_id
         }
-        response = self.request_manager.post(url, json=payload)
-        return response.json()
+        try:
+            response = self.request_manager.post(url, json=payload)
+            return response.json()
+        except ReloginRequiredException:
+            self._logger.info(f" You need to log in to the Domino UI to start the job. Please do it at {self._routes.host}")
 
     def job_stop(self, job_id: str, commit_results: bool = True):
         """

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -100,7 +100,7 @@ class Domino:
             response = self.request_manager.post(url, json=request)
             return response.json()
         except ReloginRequiredException:
-            self._logger.info(f" You need to log in to the Domino UI to start the run. Please do it at {self._routes.host}")
+            self._logger.info(f" You need to log in to the Domino UI to start the run. Please do it at {self._routes.host}/relogin?redirectPath=/")
 
     def runs_start_blocking(self, command, isDirect=False, commitId=None,
                             title=None, tier=None, publishApiEndpoint=None,
@@ -426,7 +426,7 @@ class Domino:
             response = self.request_manager.post(url, json=payload)
             return response.json()
         except ReloginRequiredException:
-            self._logger.info(f" You need to log in to the Domino UI to start the job. Please do it at {self._routes.host}")
+            self._logger.info(f" You need to log in to the Domino UI to start the job. Please do it at {self._routes.host}/relogin?redirectPath=/")
 
     def job_stop(self, job_id: str, commit_results: bool = True):
         """

--- a/domino/exceptions.py
+++ b/domino/exceptions.py
@@ -48,3 +48,7 @@ class MalformedInputException(DominoException):
 class MissingRequiredFieldException(DominoException):
     """Missing required field Exception"""
     pass
+
+class ReloginRequiredException(DominoException):
+    """Re-login required Exception"""
+    pass

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -38,7 +38,7 @@ class _HttpRequestManager:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == HTTPStatus.CONFLICT:
                 parse_result = urlparse(e.response.url)
-                self._logger.info(f" An error has occurred. Try to relogin at {parse_result.scheme}://{parse_result.netloc}")
+                self._logger.error(f" An error has occurred. Try to relogin at {parse_result.scheme}://{parse_result.netloc}")
             else:
                 # Sometimes, the error response is a long HTML page.
                 # We don't want to log error the whole response html in those cases.

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -1,7 +1,8 @@
 from bs4 import BeautifulSoup
 from http import HTTPStatus
 from requests.auth import AuthBase
-from urllib.parse import urlparse
+
+from .exceptions import ReloginRequiredException
 
 import logging
 import requests
@@ -37,8 +38,7 @@ class _HttpRequestManager:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == HTTPStatus.CONFLICT:
-                parse_result = urlparse(e.response.url)
-                self._logger.error(f" An error has occurred. Try to relogin at {parse_result.scheme}://{parse_result.netloc}")
+                raise ReloginRequiredException("Temporary credentials expired")
             # Sometimes, the error response is a long HTML page.
             # We don't want to log error the whole response html in those cases.
             if not bool(BeautifulSoup(e.response.text, "html.parser").find()):

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -39,12 +39,11 @@ class _HttpRequestManager:
             if e.response.status_code == HTTPStatus.CONFLICT:
                 parse_result = urlparse(e.response.url)
                 self._logger.error(f" An error has occurred. Try to relogin at {parse_result.scheme}://{parse_result.netloc}")
+            # Sometimes, the error response is a long HTML page.
+            # We don't want to log error the whole response html in those cases.
+            if not bool(BeautifulSoup(e.response.text, "html.parser").find()):
+                self._logger.error(e.response.text)
             else:
-                # Sometimes, the error response is a long HTML page.
-                # We don't want to log error the whole response html in those cases.
-                if not bool(BeautifulSoup(e.response.text, "html.parser").find()):
-                    self._logger.error(e.response.text)
-                else:
-                    self._logger.debug(e.response.text)
+                self._logger.debug(e.response.text)
             raise
         return response

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -46,5 +46,5 @@ class _HttpRequestManager:
                     self._logger.error(e.response.text)
                 else:
                     self._logger.debug(e.response.text)
-                raise
+            raise
         return response


### PR DESCRIPTION
Added better token expiration error handling for `job_start` and `runs_start` methods (the latter is not really necessary right now as it uses v1 API).