### PR TITLE
Updates for ITG requests

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -35,6 +35,8 @@ class Domino:
                 self._routes = _Routes(host, owner_username, project_name)
             else:
                 # Initialize without a project
+                self._logger.warn(f" Initialising without a project will cause Runs, Files,\n"
+                    + "Commits, Blobs and Model functions to become unusable")
                 self._routes = _Routes(host)
         except ValueError as e:
             self._logger.error(f"Project {project} must be given in the form username/projectname")

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -37,7 +37,7 @@ class Domino:
                 # Initialize without a project
                 self._routes = _Routes(host)
         except ValueError as e:
-            self._logger.error(f"Project {project} must blank or be given in the form username/projectname")
+            self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
 
         domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -77,6 +77,7 @@ class Domino:
             if not self._project_included:
                 raise MissingRequiredFieldException(f"Object must be initialised with" 
                     f" Project name to use the {fn.__name__} method")
+            return fn(self, *args, **kwargs)
         return wrapper
 
     def _configure_logging(self):

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -40,7 +40,7 @@ class Domino:
             self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
 
-        domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
+        #domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
         api_key = api_key or os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
 
         # This call sets self.request_manager
@@ -615,13 +615,21 @@ class Domino:
         """
         url = self._routes.users_get()
         response = self.request_manager.get(url)
-        resp = response.json()
+        users = response.json()
 
-        users = []
-        for user in resp:
-            if  user.get('email') and "@example.com" not in user.get('email'):
-                users.append(user)
-                
+        url = self._routes.orgs_get()
+        response = self.request_manager.get(url)
+        orgs = response.json()
+
+        del_users = []
+        for i in range(0,len(users)):
+            for org in orgs:
+                if users[i].get('id') == org.get("organizationUserId"):
+                    del_users.append(i)
+
+        for ele in sorted(del_users, reverse=True):
+            del users[ele]            
+
         return users
 
     def orgs_list(self):

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -33,11 +33,13 @@ class Domino:
             if project:
                 owner_username, project_name = project.split("/")
                 self._routes = _Routes(host, owner_username, project_name)
+                self._project_included = True
             else:
                 # Initialize without a project
                 self._logger.warn(f" Initialising without a project will cause Runs, Files,\n"
                     + "Commits, Blobs and Model functions to become unusable")
                 self._routes = _Routes(host)
+                self._project_included = False
         except ValueError as e:
             self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
@@ -66,6 +68,16 @@ class Domino:
         except AttributeError:
             self._configure_logging()
             return self._logger
+    
+    def _check_project(fn):
+        """
+        Decorator to check if class is initialised with project
+        """
+        def wrapper(self, *args, **kwargs):
+            if not self._project_included:
+                raise MissingRequiredFieldException(f"Object must be initialised with" 
+                    f" Project name to use the {fn.__name__} method")
+        return wrapper
 
     def _configure_logging(self):
         logging_level = logging.getLevelName(os.getenv(DOMINO_LOG_LEVEL_KEY_NAME, "INFO").upper())
@@ -81,14 +93,17 @@ class Domino:
                                                                     auth_token=auth_token,
                                                                     domino_token_file=domino_token_file))
 
+    @_check_project
     def commits_list(self):
         url = self._routes.commits_list()
         return self._get(url)
 
+    @_check_project
     def runs_list(self):
         url = self._routes.runs_list()
         return self._get(url)
 
+    @_check_project
     def runs_start(self, command, isDirect=False, commitId=None, title=None,
                    tier=None, publishApiEndpoint=None):
 
@@ -108,6 +123,7 @@ class Domino:
         except ReloginRequiredException:
             self._logger.info(f" You need to log in to the Domino UI to start the run. Please do it at {self._routes.host}/relogin?redirectPath=/")
 
+    @_check_project
     def runs_start_blocking(self, command, isDirect=False, commitId=None,
                             title=None, tier=None, publishApiEndpoint=None,
                             poll_freq=5, max_poll_time=6000, retry_count=5):
@@ -202,14 +218,17 @@ class Domino:
 
         return run_response
 
+    @_check_project
     def run_stop(self, runId, saveChanges=True):
         self.log.warning("Use job_stop method instead")
         return self.job_stop(job_id=runId, commit_results=saveChanges)
 
+    @_check_project
     def runs_status(self, runId):
         url = self._routes.runs_status(runId)
         return self._get(url)
 
+    @_check_project
     def get_run_log(self, runId, includeSetupLog=True):
         """
         Get the unified log for a run (setup + stdout).
@@ -233,11 +252,13 @@ class Domino:
 
         return "\n".join(logs)
 
+    @_check_project
     def get_run_info(self, run_id):
         for run_info in self.runs_list()['data']:
             if run_info['id'] == run_id:
                 return run_info
 
+    @_check_project
     def runs_stdout(self, runId):
         """
         Get std out emitted by a particular run.
@@ -251,6 +272,7 @@ class Domino:
         # pprint.pformat outputs a string that is ready to be printed
         return pprint.pformat(self._get(url)['stdout'])
 
+    @_check_project
     def job_start(
             self,
             command: str,
@@ -448,6 +470,7 @@ class Domino:
         except ReloginRequiredException:
             self._logger.info(f" You need to log in to the Domino UI to start the job. Please do it at {self._routes.host}/relogin?redirectPath=/")
 
+    @_check_project
     def job_stop(self, job_id: str, commit_results: bool = True):
         """
         Stops the Job with given job_id
@@ -473,6 +496,7 @@ class Domino:
             self._routes.job_status(job_id)
         ).json()
 
+    @_check_project
     def job_start_blocking(self, poll_freq: int = 5, max_poll_time: int = 6000,
                            ignore_exceptions: Tuple = (requests.exceptions.RequestException,),
                            **kwargs) -> dict:
@@ -505,34 +529,41 @@ class Domino:
         self.process_log(stdout_msg)
         return job_status
 
+    @_check_project
     def files_list(self, commitId, path='/'):
         url = self._routes.files_list(commitId, path)
         return self._get(url)
 
+    @_check_project
     def files_upload(self, path, file):
         url = self._routes.files_upload(path)
         return self._put_file(url, file)
 
+    @_check_project
     def blobs_get(self, key):
         self._validate_blob_key(key)
         url = self._routes.blobs_get(key)
         return self.request_manager.get_raw(url)
 
+    @_check_project
     def fork_project(self, target_name):
         url = self._routes.fork_project(self._project_id)
         request = {"name": target_name}
         response = self.request_manager.post(url, json=request)
         return response
 
+    @_check_project
     def endpoint_state(self):
         url = self._routes.endpoint_state()
         return self._get(url)
 
+    @_check_project
     def endpoint_unpublish(self):
         url = self._routes.endpoint()
         response = self.request_manager.delete(url)
         return response
 
+    @_check_project
     def endpoint_publish(self, file, function, commitId):
         url = self._routes.endpoint_publish()
 
@@ -582,6 +613,7 @@ class Domino:
         response = self.request_manager.get(url, params=query)
         return response.json()
 
+    @_check_project
     def collaborators_get(self):
         self.requires_at_least("1.53.0.0")
         url = self._routes.collaborators_get()
@@ -648,6 +680,7 @@ class Domino:
                 
         return orgs
 
+    @_check_project
     def collaborators_add(self, username_or_email, message=""):
         self.requires_at_least("1.53.0.0")
 
@@ -665,6 +698,7 @@ class Domino:
         response = self.request_manager.post(url, json=request)
         return response
 
+    @_check_project
     def collaborators_remove(self, username_or_email):
         self.requires_at_least("1.53.0.0")
 
@@ -679,6 +713,7 @@ class Domino:
         return response
 
     # App functions
+    @_check_project
     def app_publish(self, unpublishRunningApps=True, hardwareTierId=None):
         if unpublishRunningApps:
             self.app_unpublish()
@@ -693,6 +728,7 @@ class Domino:
         response = self.request_manager.post(url, json=request)
         return response
 
+    @_check_project
     def app_unpublish(self):
         app_id = self._app_id
         if app_id is None:
@@ -763,11 +799,13 @@ class Domino:
         return self._get(url)
 
     # Model Manager functions
+    @_check_project
     def models_list(self):
         self.requires_at_least("2.5.0")
         url = self._routes.models_list()
         return self._get(url)
 
+    @_check_project
     def model_publish(self, file, function, environment_id, name,
                       description, files_to_exclude=[]):
         self.requires_at_least("2.5.0")
@@ -792,6 +830,7 @@ class Domino:
         url = self._routes.model_versions_get(model_id)
         return self._get(url)
 
+    @_check_project
     def model_version_publish(self, model_id, file, function, environment_id,
                               description, files_to_exclude=[]):
         self.requires_at_least("2.5.0")
@@ -860,6 +899,7 @@ class Domino:
         return self._get(url)
 
     # Hardware Tier Functions
+    @_check_project    
     def hardware_tiers_list(self):
         url = self._routes.hardware_tiers_list(self._project_id)
         return self._get(url)
@@ -905,6 +945,7 @@ class Domino:
                 return True
         raise HardwareTierNotFoundException(f"{hardware_tier_name} hardware tier name not found")
 
+    @_check_project
     def _validate_commit_id(self, commit_id):
         self.log.debug(f"Validating commit id: {commit_id}")
         for commit in self.commits_list():
@@ -950,8 +991,10 @@ class Domino:
                 at_least_version, self._version))
 
     # Workaround to get project ID which is needed for some model functions
+    # Added catch-all check for @_check_project as well
     @property
     @functools.lru_cache()
+    @_check_project
     def _project_id(self):
         url = self._routes.find_project_by_owner_name_and_project_name_url()
         key = "id"

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -40,7 +40,7 @@ class Domino:
             self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
 
-        #domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
+        domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
         api_key = api_key or os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
 
         # This call sets self.request_manager
@@ -611,7 +611,7 @@ class Domino:
         Return a list of all users available
 
         Return:
-           users (dict): Details of all users
+           users (list): Details of all users
         """
         url = self._routes.users_get()
         response = self.request_manager.get(url)
@@ -634,10 +634,11 @@ class Domino:
 
     def orgs_list(self):
         """
-        Return a list of all orgs available. Admin API
+        Return a list of all orgs available. Requires admin level access.
+        If a user without SysAdmin calls this it will return a 403
 
         Return:
-           orgs (dict): Details of all orgs
+           orgs (list): Details of all orgs
         """
         url = self._routes.orgs_get()
         response = self.request_manager.get(url)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -20,7 +20,7 @@ from bs4 import BeautifulSoup
 
 
 class Domino:
-    def __init__(self, project, api_key=None, host=None, domino_token_file=None, auth_token=None):
+    def __init__(self, project=None, api_key=None, host=None, domino_token_file=None, auth_token=None):
 
         self._configure_logging()
 
@@ -30,10 +30,14 @@ class Domino:
         host = clean_host_url(_host)
 
         try:
-            owner_username, project_name = project.split("/")
-            self._routes = _Routes(host, owner_username, project_name)
+            if project:
+                owner_username, project_name = project.split("/")
+                self._routes = _Routes(host, owner_username, project_name)
+            else:
+                # Initialize without a project
+                self._routes = _Routes(host)
         except ValueError as e:
-            self._logger.error(f"Project {project} must be given in the form username/projectname")
+            self._logger.error(f"Project {project} must blank or be given in the form username/projectname")
             raise
 
         domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
@@ -601,6 +605,37 @@ class Domino:
                 user_id = user['id']
                 break
         return user_id
+
+    def users_list(self):
+        """
+        Return a list of all users available
+
+        Return:
+           users (dict): Details of all users
+        """
+        url = self._routes.users_get()
+        response = self.request_manager.get(url)
+        resp = response.json()
+
+        users = []
+        for user in resp:
+            if  user.get('email') and "@example.com" not in user.get('email'):
+                users.append(user)
+                
+        return users
+
+    def orgs_list(self):
+        """
+        Return a list of all orgs available. Admin API
+
+        Return:
+           orgs (dict): Details of all orgs
+        """
+        url = self._routes.orgs_get()
+        response = self.request_manager.get(url)
+        orgs = response.json()
+                
+        return orgs
 
     def collaborators_add(self, username_or_email, message=""):
         self.requires_at_least("1.53.0.0")

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -1,22 +1,35 @@
+from .exceptions import MissingRequiredFieldException
+
 class _Routes:
-    def __init__(self, host, owner_username=None, project_name='quick-start'):
+    def __init__(self, host, owner_username=None, project_name=None):
         self.host = host
         self._owner_username = owner_username
         self._project_name = project_name
 
     # URL builders
     def _build_project_url(self):
-        return self.host + '/v1/projects/' + \
-            self._owner_username + '/' + self._project_name
+        if self._project_name:
+            return self.host + '/v1/projects/' + \
+                self._owner_username + '/' + self._project_name
+        else:
+            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
 
     def _build_project_url_private_api(self):
-        return self.host + '/u/' + self._owner_username + \
-            '/' + self._project_name
+        if self._project_name:
+            return self.host + '/u/' + self._owner_username + \
+                '/' + self._project_name
+        else:
+            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
+
 
     def _build_old_project_url(self):
-        # TODO refactor once these API endpoints are supported in REST API
-        return self.host + '/' \
-            + self._owner_username + '/' + self._project_name
+        if self._project_name:
+            # TODO refactor once these API endpoints are supported in REST API
+            return self.host + '/' \
+                + self._owner_username + '/' + self._project_name
+        else:
+            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
+
 
     def _build_models_url(self):
         return self.host + '/v1/models'
@@ -155,8 +168,11 @@ class _Routes:
 
     # Find Project By OwnerName and project name Url
     def find_project_by_owner_name_and_project_name_url(self):
-        return f'{self.host}/v4/gateway/projects/findProjectByOwnerAndName' \
-               f'?ownerName={self._owner_username}&projectName={self._project_name}'
+        if self._project_name:
+            return f'{self.host}/v4/gateway/projects/findProjectByOwnerAndName' \
+                f'?ownerName={self._owner_username}&projectName={self._project_name}'
+        else:
+            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
 
     # User URLs
     def users_get(self):

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -1,5 +1,5 @@
 class _Routes:
-    def __init__(self, host, owner_username, project_name):
+    def __init__(self, host, owner_username=None, project_name='quick-start'):
         self.host = host
         self._owner_username = owner_username
         self._project_name = project_name
@@ -161,3 +161,7 @@ class _Routes:
     # User URLs
     def users_get(self):
         return self.host + f'/v4/users'
+
+    #Organizations
+    def orgs_get(self):
+        return self.host + f'/v4/organizations'

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -1,5 +1,3 @@
-from .exceptions import MissingRequiredFieldException
-
 class _Routes:
     def __init__(self, host, owner_username=None, project_name=None):
         self.host = host
@@ -8,27 +6,17 @@ class _Routes:
 
     # URL builders
     def _build_project_url(self):
-        if self._project_name:
-            return self.host + '/v1/projects/' + \
+        return self.host + '/v1/projects/' + \
                 self._owner_username + '/' + self._project_name
-        else:
-            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
 
     def _build_project_url_private_api(self):
-        if self._project_name:
-            return self.host + '/u/' + self._owner_username + \
+        return self.host + '/u/' + self._owner_username + \
                 '/' + self._project_name
-        else:
-            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
-
 
     def _build_old_project_url(self):
-        if self._project_name:
-            # TODO refactor once these API endpoints are supported in REST API
-            return self.host + '/' \
-                + self._owner_username + '/' + self._project_name
-        else:
-            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
+        # TODO refactor once these API endpoints are supported in REST API
+        return self.host + '/' \
+            + self._owner_username + '/' + self._project_name
 
 
     def _build_models_url(self):
@@ -168,11 +156,8 @@ class _Routes:
 
     # Find Project By OwnerName and project name Url
     def find_project_by_owner_name_and_project_name_url(self):
-        if self._project_name:
-            return f'{self.host}/v4/gateway/projects/findProjectByOwnerAndName' \
-                f'?ownerName={self._owner_username}&projectName={self._project_name}'
-        else:
-            raise MissingRequiredFieldException("Object must be initialised with Project name to use this method")
+        return f'{self.host}/v4/gateway/projects/findProjectByOwnerAndName' \
+            f'?ownerName={self._owner_username}&projectName={self._project_name}'
 
     # User URLs
     def users_get(self):


### PR DESCRIPTION
- Ability to initialise without a project defined - specifically requested by ITG admins. This does leave some endpoints unusable in routes, have added warning and exceptions when trying to use these routes without specifying a project.
- Orgs_list, users_list calls for admins - along the lines of environments_list, models_list. Orgs list only works for sysadmins

Jira: https://dominodatalab.atlassian.net/browse/DOM-33605