### PR TITLE
Use type checking compatible with 3.8 python

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 from .routes import _Routes
 from .helpers import *
@@ -253,7 +253,7 @@ class Domino:
             environment_id: Optional[str] = None,
             on_demand_spark_cluster_properties: Optional[dict] = None,
             compute_cluster_properties: Optional[dict] = None,
-            external_volume_mounts: Optional[list[str]] = None,
+            external_volume_mounts: Optional[List[str]] = None,
     ) -> dict:
         """
         Starts a Domino Job via V4 API


### PR DESCRIPTION
### Problem
Python-domino type checking with lowercase `list` only works with 3.9

### Solution
Use upper case `List` and import from `typing`

### Testing
Described in the comments of the ticket below

### JIRA
[DOM-33608](https://dominodatalab.atlassian.net/browse/DOM-33608)