### PR TITLE
Update domino to accept version as a parameter

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -20,7 +20,7 @@ from bs4 import BeautifulSoup
 
 
 class Domino:
-    def __init__(self, project, api_key=None, host=None, domino_token_file=None, auth_token=None):
+    def __init__(self, project, version=None, api_key=None, host=None, domino_token_file=None, auth_token=None):
 
         self._configure_logging()
 
@@ -43,7 +43,10 @@ class Domino:
         self.authenticate(api_key, auth_token, domino_token_file)
 
         # Get version
-        self._version = self.deployment_version().get("version")
+        if version:
+            self._version = version
+        else:
+            self._version = self.deployment_version().get("version")
         self._logger.info(f"Domino deployment {host} is running version {self._version}")
 
         # Check version compatibility


### PR DESCRIPTION
the version API is in the direct domain host without `/v1` or `/v4` path, this will block the API access if configured with SSO.
This fix will accept version as a parameter when using the API