### PR TITLE
Fixing precedence of authentication methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Updated authentication methods precedence.
 
 ## 1.0.7
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can set up the connection by creating new instance of `Domino`.
 
 <hr>
 
-### *class* Domino(project, api_key=None, host=None, domino_token_file=None)
+### *class* Domino(project, api_key=None, host=None, domino_token_file=None, auth_token=None)
 
 The parameters are:
 
@@ -51,9 +51,13 @@ The parameters are:
   environment variable.
 * *domino_token_file:* (Optional) Path to domino token file containing auth token. If not provided the library will expect to find one
 in the DOMINO_TOKEN_FILE environment variable.
+* *auth_token:* (Optional) Authentication token
 
 Note:
-1. In case both api_key and domino_token_file are available, then preference will be given to domino_token_file.
+1. The preference is always given to authentication token. If it's not passed, the path to domino token file
+takes precedence, if it is explicitly passed as a parameter, otherwise the API key is used. If none of these three
+parameters is passed,  then preference will be given to domino_token_file from the environment variable, then
+to the API key from the environment variable
 2. By default the log level is set to `INFO`, to set log level to `DEBUG`, set `DOMINO_LOG_LEVEL` environment variable to `DEBUG`
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ in the DOMINO_TOKEN_FILE environment variable.
 * *auth_token:* (Optional) Authentication token
 
 Note:
-1. The preference is always given to authentication token. If it's not passed, the path to domino token file
-takes precedence, if it is explicitly passed as a parameter, otherwise the API key is used. If none of these three
-parameters is passed,  then preference will be given to domino_token_file from the environment variable, then
-to the API key from the environment variable
+1. The authentication preference should always be given to the authentication token. If it's not passed, the path to domino token file
+takes precedence, otherwise the API key is used. If none of these three parameters are passed, then preference will be given to the
+domino token file from the corresponding environment variable, then to the API key from the corresponding environment variable.
 2. By default the log level is set to `INFO`, to set log level to `DEBUG`, set `DOMINO_LOG_LEVEL` environment variable to `DEBUG`
 <hr>
 

--- a/domino/authentication.py
+++ b/domino/authentication.py
@@ -1,5 +1,9 @@
 from requests.auth import AuthBase, HTTPBasicAuth
 
+from .constants import *
+
+import os
+
 
 class BearerAuth(AuthBase):
     """
@@ -26,7 +30,7 @@ class BearerAuth(AuthBase):
         return r
 
 
-def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None, api_key_from_env=None, domino_token_file_from_env=None):
+def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None):
     """
     Return appropriate authentication object for requests.
 
@@ -40,9 +44,6 @@ def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None, api_
         5. api_key_from_env
     """
 
-    assert any([api_key, auth_token, domino_token_file, api_key_from_env, domino_token_file_from_env]), \
-        "Unable to authenticate: no authentication method provided"
-
     if auth_token is not None:
         return BearerAuth(auth_token=auth_token)
     elif domino_token_file is not None:
@@ -50,5 +51,12 @@ def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None, api_
     elif api_key is not None:
         return HTTPBasicAuth('', api_key)
     else:
-        return self.get_auth_by_type(api_key=api_key_from_env, domino_token_file=domino_token_file_from_env)
-
+        # In the case that no authentication type was passed when this method
+        # called, fall back to deriving the auth info from the environment.
+        api_key_from_env = os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
+        domino_token_file_from_env = os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
+        if api_key_from_env or domino_token_file_from_env:
+            return get_auth_by_type(api_key=api_key_from_env, domino_token_file=domino_token_file_from_env)
+        else:
+            # All attempts failed -- nothing to do but raise an error.
+            raise RuntimeError("Unable to authenticate: no authentication provided")

--- a/domino/authentication.py
+++ b/domino/authentication.py
@@ -26,24 +26,29 @@ class BearerAuth(AuthBase):
         return r
 
 
-def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None):
+def get_auth_by_type(api_key=None, auth_token=None, domino_token_file=None, api_key_from_env=None, domino_token_file_from_env=None):
     """
     Return appropriate authentication object for requests.
 
     If no authentication credential is provided, the call fails with an AssertError
 
     Precedence in the case of multiple credentials is:
-        1. auth token string
-        2. token file
-        3. API key
+        1. auth_token string
+        2. domino_token_file
+        3. api_key
+        4. domino_token_file_from_env
+        5. api_key_from_env
     """
 
-    assert any([api_key, auth_token, domino_token_file]), \
+    assert any([api_key, auth_token, domino_token_file, api_key_from_env, domino_token_file_from_env]), \
         "Unable to authenticate: no authentication method provided"
 
     if auth_token is not None:
         return BearerAuth(auth_token=auth_token)
     elif domino_token_file is not None:
         return BearerAuth(domino_token_file=domino_token_file)
-    else:
+    elif api_key is not None:
         return HTTPBasicAuth('', api_key)
+    else:
+        return self.get_auth_by_type(api_key=api_key_from_env, domino_token_file=domino_token_file_from_env)
+

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -70,9 +70,7 @@ class Domino:
         """
         self.request_manager = _HttpRequestManager(get_auth_by_type(api_key=api_key,
                                                                     auth_token=auth_token,
-                                                                    domino_token_file=domino_token_file,
-                                                                    api_key_from_env=os.getenv(DOMINO_USER_API_KEY_KEY_NAME),
-                                                                    domino_token_file_from_env=os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)))
+                                                                    domino_token_file=domino_token_file))
 
     def commits_list(self):
         url = self._routes.commits_list()

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -36,11 +36,21 @@ class Domino:
             self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
 
-        domino_token_file = domino_token_file or os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
-        api_key = api_key or os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
+        # See `README.md` for the precedence explanation
+        actual_api_key = None
+        actual_domino_token_file = None
+
+        if not auth_token:
+            if domino_token_file:
+                actual_domino_token_file = domino_token_file
+            elif api_key:
+                actual_api_key = api_key
+            else:
+                actual_api_key = os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
+                actual_domino_token_file = os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
 
         # This call sets self.request_manager
-        self.authenticate(api_key, auth_token, domino_token_file)
+        self.authenticate(actual_api_key, auth_token, actual_domino_token_file)
 
         # Get version
         self._version = self.deployment_version().get("version")

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -36,21 +36,8 @@ class Domino:
             self._logger.error(f"Project {project} must be given in the form username/projectname")
             raise
 
-        # See `README.md` for the precedence explanation
-        actual_api_key = None
-        actual_domino_token_file = None
-
-        if not auth_token:
-            if domino_token_file:
-                actual_domino_token_file = domino_token_file
-            elif api_key:
-                actual_api_key = api_key
-            else:
-                actual_api_key = os.getenv(DOMINO_USER_API_KEY_KEY_NAME)
-                actual_domino_token_file = os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)
-
         # This call sets self.request_manager
-        self.authenticate(actual_api_key, auth_token, actual_domino_token_file)
+        self.authenticate(api_key, auth_token, domino_token_file)
 
         # Get version
         self._version = self.deployment_version().get("version")
@@ -83,7 +70,9 @@ class Domino:
         """
         self.request_manager = _HttpRequestManager(get_auth_by_type(api_key=api_key,
                                                                     auth_token=auth_token,
-                                                                    domino_token_file=domino_token_file))
+                                                                    domino_token_file=domino_token_file,
+                                                                    api_key_from_env=os.getenv(DOMINO_USER_API_KEY_KEY_NAME),
+                                                                    domino_token_file_from_env=os.getenv(DOMINO_TOKEN_FILE_KEY_NAME)))
 
     def commits_list(self):
         url = self._routes.commits_list()

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -20,7 +20,7 @@ def test_no_auth_type_error():
     """
     dummy_host = "http://domino.somefakecompany.com"
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError):
         Domino(host=dummy_host, project="anyuser/quick-start")
 
 
@@ -126,7 +126,7 @@ def test_auth_token_precedence():
 
 @pytest.mark.usefixtures("mock_domino_version_response")
 @pytest.mark.skipif(not os.getenv(DOMINO_TOKEN_FILE_KEY_NAME), reason="No token file in environment")  # noqa:E501
-def test_auth_with_only_api_key_passed_as_parameter():
+def test_auth_with_api_key_and_env_token_file():
     """
     Confirm that api key takes precedence over both token file and API key authentication
     if they are not passed as parameters.

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -125,6 +125,21 @@ def test_auth_token_precedence():
 
 
 @pytest.mark.usefixtures("mock_domino_version_response")
+@pytest.mark.skipif(not os.getenv(DOMINO_TOKEN_FILE_KEY_NAME), reason="No token file in environment")  # noqa:E501
+def test_auth_with_only_api_key_passed_as_parameter():
+    """
+    Confirm that api key takes precedence over both token file and API key authentication
+    if they are not passed as parameters.
+    """
+    dummy_host = "http://domino.somefakecompany.com"
+    dummy_api_key = "top_secret_api_key"
+
+    d = Domino(host=dummy_host, project="anyuser/quick-start", api_key=dummy_api_key)
+    assert isinstance(d.request_manager.auth, requests.auth.HTTPBasicAuth), \
+        "With only api key passed as a parameter, it takes precedence over DOMINO_TOKEN_FILE_KEY_NAME"
+
+
+@pytest.mark.usefixtures("mock_domino_version_response")
 def test_token_file_precedence(dummy_token_file):
     """
     Confirm that token file authentication takes precedence over API key authentication.


### PR DESCRIPTION
When instantiating `Domino` object, the authentication preference should always be given to the authentication token. If it's not passed, the path to domino token file takes precedence, otherwise the API key is used. If none of these three parameters are passed, then preference will be given to the domino token file from the corresponding environment variable, then to the API key from the corresponding environment variable.