### PR TITLE
Fix issues with missing import from domino-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Changed
 * updated airflow dependency 2.2.4
 * Updated runs_stdout output
+* Fixed issues with import from domino_data
 
 ## 1.0.8
 

--- a/domino/data_sources.py
+++ b/domino/data_sources.py
@@ -21,4 +21,4 @@ def __getattr__(value):
         import domino_data.data_sources
     except ImportError as e:
         raise ImportError(_import_error_message) from e
-    return getattr(domino_data, value)
+    return getattr(domino_data.data_sources, value)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+
+@pytest.mark.skipif(os.getenv("DATA_SDK") != "yes", reason="Extra dependency required")
+def test_data_sources_import():
+    from domino.data_sources import DataSourceClient
+    from domino.data_sources import ADLSConfig
+
+    assert DataSourceClient
+    assert ADLSConfig
+
+
+@pytest.mark.skipif(os.getenv("DATA_SDK") != "yes", reason="Extra dependency required")
+def test_data_sources_import_cant_find():
+    try:
+        from domino.data_sources import NotADatasourceConfig  # noqa
+    except ImportError as exc:
+        assert (
+            "cannot import name 'NotADatasourceConfig' from 'domino.data_sources'"
+            in str(exc)
+        )
+
+
+@pytest.mark.skipif(
+    os.getenv("DATA_SDK") == "yes", reason="Testing failure when dependency is missing"
+)
+def test_data_sources_import_fails():
+    try:
+        from domino.data_sources import DataSourceClient  # noqa
+    except ImportError as exc:
+        assert "Please pip install dominodatalab-data" in str(exc)
+    else:
+        assert (
+            False
+        ), "Import should be failing when dominodatalab-data is not installed"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py38,nosdk
+
+[testenv]
+deps =
+    pytest
+    requests-mock
+    dominodatalab-data
+setenv =
+    DATA_SDK = yes
+commands =
+    pytest tests/test_data_sources.py
+
+[testenv:nosdk]
+deps =
+    pytest
+    requests-mock
+setenv =
+    DATA_SDK = no
+commands =
+    pytest tests/test_data_sources.py

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,21 @@
 [tox]
 envlist = py38,nosdk
 
+# NOTE: this should be extended to run all tests but there are a LOT of dependencies
+# to be figured out and tests to be fixed. I added some dependencies and the basic
+# pytest command to be run once tests are cleaned up.
 [testenv]
 deps =
     pytest
     requests-mock
     dominodatalab-data
+#    pyspark
+#    apache-airflow
+#    pandas
 setenv =
     DATA_SDK = yes
 commands =
+#    pytest tests/
     pytest tests/test_data_sources.py
 
 [testenv:nosdk]


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-38900

### What issue does this pull request solve?

Implementation of __getattr__ is not looking for objects in the right module

### What is the solution?

Use `getattr` on the right module

### Testing

Tested in a deployment (by upload tar dist and installing manually)

- [x] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [x] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
