### PR TITLE
[DOM-39831] - added forward slash check for file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 * Fixed issues with import from domino_data
 * Updated nbconvert dependency version to 6.3.0
 * updated request user-agent to python-domino/{version}
+* Changed file handling for `files_upload`
 
 ## 1.0.8
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -667,6 +667,8 @@ class Domino:
         return self._get(url)
 
     def files_upload(self, path, file):
+        if path[0] != "/":
+            path = "/" + path
         url = self._routes.files_upload(path)
         return self._put_file(url, file)
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -17,7 +17,7 @@ from domino.constants import (
     DOMINO_HOST_KEY_NAME,
     DOMINO_LOG_LEVEL_KEY_NAME,
     MINIMUM_EXTERNAL_VOLUME_MOUNTS_SUPPORT_DOMINO_VERSION,
-    MINIMUM_GA_DOMINO_VERSION,
+    MINIMUM_SUPPORTED_DOMINO_VERSION,
     MINIMUM_ON_DEMAND_SPARK_CLUSTER_SUPPORT_DOMINO_VERSION,
 )
 from domino.http_request_manager import _HttpRequestManager
@@ -52,7 +52,7 @@ class Domino:
 
         # Get version
         self._version = self.deployment_version().get("version")
-        assert self.requires_at_least(MINIMUM_GA_DOMINO_VERSION)
+        assert self.requires_at_least(MINIMUM_SUPPORTED_DOMINO_VERSION)
 
         self._logger.debug(
             f"Domino deployment {host} is running version {self._version}"
@@ -667,7 +667,7 @@ class Domino:
         return self._get(url)
 
     def files_upload(self, path, file):
-        if path[0] != "/":
+        if not path.startswith("/"):
             path = "/" + path
         url = self._routes.files_upload(path)
         return self._put_file(url, file)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -87,6 +87,17 @@ def test_upload_file_to_project(default_domino_client):
     assert response.status_code == 201
     assert response.json()["path"] == "test_file.py"
 
+def test_upload_file_to_project_without_forward_slash(default_domino_client):
+    """
+    Confirm that the python-domino client can upload a file to a project.
+    """
+    with open(__file__, "rb") as test_file:
+        response = default_domino_client.files_upload(
+            path="test_file.py", file=test_file
+        )
+    assert response.status_code == 201
+    assert response.json()["path"] == "test_file.py"
+
 
 @pytest.mark.skipif(
     not domino_is_reachable(), reason="No access to a live Domino deployment"


### PR DESCRIPTION
### Link to JIRA

[DOM-39831](https://dominodatalab.atlassian.net/browse)

### What issue does this pull request solve?

When a file that is being uploaded does not have a forward slash at the beginning it throws an error

### What is the solution?

Added a checker to make sure the file still gets uploaded either way.

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
- https://github.com/dominodatalab/python-domino/issues/33
