### PR TITLE
DOM-41687 Use reverse proxy for authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can set up the connection by creating a new instance of `Domino`:
 -   *project:* A project identifier (in the form of
     ownerusername/projectname).
     
--   *api_proxy:* (Optional) Location of the Domino API proxy as host:port.
+-   *api_proxy:* (Optional) Location of the Domino API reverse proxy as host:port.
     If set, this proxy will be used to intercept any Domino API requests and insert an auth token.
     This is the preferred method of authentication. Alternatively, the same behavior can be achieved
     by setting the `DOMINO_API_PROXY` environment variable (this variable is set inside a Domino run

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -101,6 +101,21 @@ def test_object_creation_with_api_proxy():
     assert isinstance(
         d.request_manager.auth, domino.authentication.ProxyAuth
     ), "Authentication using API proxy should be of type domino.authentication.ProxyAuth"
+    assert d.request_manager.auth.api_proxy == "http://localhost:1234"
+
+@pytest.mark.usefixtures("mock_domino_version_response", "clear_token_file_from_env")
+def test_object_creation_with_api_proxy_with_scheme():
+    """
+    Confirm that the expected auth type is used when using api proxy.
+    """
+    dummy_host = "http://domino.somefakecompany.com"
+    dummy_api_proxy = "https://localhost:1234"
+
+    d = Domino(host=dummy_host, project="anyuser/quick-start", api_key=dummy_api_proxy)
+    assert isinstance(
+        d.request_manager.auth, domino.authentication.ProxyAuth
+    ), "Authentication using API proxy should be of type domino.authentication.ProxyAuth"
+    assert d.request_manager.auth.api_proxy == "https://localhost:1234"
 
 
 @pytest.mark.usefixtures("mock_domino_version_response")


### PR DESCRIPTION
### Link to JIRA

[DOM-41687](https://dominodatalab.atlassian.net/browse/DOM-41687)

### What issue does this pull request solve?

The Domino API Proxy is now a reverse proxy

### What is the solution?

Intercept requests, replace API host/port with proxy host/port

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

Unit tests

- [x] Unit test(s)

### Pull Request Reminders

- [x] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
