### PR TITLE
[DOM-42181] - set minimum python versions requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Added python versions check upon dominodatalab installation
 * Added parameter `compute_cluster_properties` to DominoSparkOperator
 
 ## 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 import pathlib
 import re
+import sys
 
 from setuptools import find_packages, setup
+
+if sys.version_info < (3,8):
+    message = f"dominodatalab requires Python '>=3.8.0' but the running Python is {'.'.join(map(str,sys.version_info[:3]))}"
+    message += "\nYou should consider Checking python-domino and domino compatibility"
+    sys.exit(message)
 
 PACKAGE_NAME = "domino"
 
@@ -39,7 +45,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
-    python_requires='>3.8.0',
+    python_requires='>=3.8.0',
     install_requires=["packaging", "requests>=2.4.2", "bs4==0.*,>=0.0.1", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2"],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
+    python_requires='>3.8.0',
     install_requires=["packaging", "requests>=2.4.2", "bs4==0.*,>=0.0.1", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2"],
     extras_require={


### PR DESCRIPTION
### Link to JIRA

[DOM-42181](https://dominodatalab.atlassian.net/browse/DOM-42181)

### What issue does this pull request solve?
Python domino fails on installation of python < 3.8

### What is the solution?
Limits minimum version of python required to install newer version of python-domino

### Testing
Installation testing

### Pull Request Reminders

- [x] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [x] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
