### PR TITLE
[DOM-43066] - DominoSparkOperator update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Updated DominoSparkOperator test for `compute_cluster_properties`
+* Set minimum python version required to ">=3.7"
 
 ## 1.2.1
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -357,7 +357,7 @@ class Domino:
         :param compute_cluster_properties:          dict (Optional)
                                                     The compute cluster properties definition contains parameters for
                                                     launching any Domino supported compute cluster for a job. Use this
-                                                    to launch a job that uses a compute cluster instead of
+                                                    to launch a job that uses compute cluster instead of
                                                     the deprecated on_demand_spark_cluster_properties field. If
                                                     on_demand_spark_cluster_properties and compute_cluster_properties
                                                     are both present, on_demand_spark_cluster_properties will be ignored.

--- a/examples/models_and_environments.py
+++ b/examples/models_and_environments.py
@@ -3,7 +3,7 @@ import os
 from domino import Domino
 
 domino = Domino(
-    "marks/quick-start-fork",
+    os.environ['DOMINO_TEST_PROJECT'],
     api_key=os.environ["DOMINO_USER_API_KEY"],
     host=os.environ["DOMINO_API_HOST"],
 )
@@ -17,7 +17,7 @@ global_environments = list(
 )
 print(
     "This Domino deployment has \
-      {} gloabl environments".format(
+      {} global environments".format(
         len(global_environments)
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3,8):
-    message = f"dominodatalab requires Python '>=3.8.0' but the running Python is {'.'.join(map(str,sys.version_info[:3]))}"
-    message += "\nYou should consider Checking python-domino and domino compatibility"
+if sys.version_info < (3,7):
+    message = f"dominodatalab requires Python '>=3.7.0' but the running Python is {'.'.join(map(str,sys.version_info[:3]))}"
+    message += "\nConsider Checking python-domino and domino compatibility"
     sys.exit(message)
 
 PACKAGE_NAME = "domino"
@@ -45,7 +45,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
-    python_requires='>=3.8.0',
+    python_requires='>=3.7.0',
     install_requires=["packaging", "requests>=2.4.2", "bs4==0.*,>=0.0.1", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2"],
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,9 +40,9 @@ def default_domino_client():
 
 
 @pytest.fixture(scope="module")
-def spark_environment_id():
+def spark_compute_env_id():
     """
-    Module-scoped fixture that uses default authentiation, and provides a Domino client object.
+    Module-scoped fixture that uses default authentication, and provides a Domino client object.
     """
     host = os.getenv(DOMINO_HOST_KEY_NAME)
     user = os.getenv(DOMINO_USER_NAME_KEY_NAME)
@@ -59,6 +59,29 @@ def spark_environment_id():
 
     for env in env_list["data"]:
         if "Spark Compute Environment" in env["name"]:
+            return env["id"]
+
+
+@pytest.fixture(scope="module")
+def spark_cluster_env_id():
+    """
+    Module-scoped fixture that uses default authentication, and provides a Domino client object.
+    """
+    host = os.getenv(DOMINO_HOST_KEY_NAME)
+    user = os.getenv(DOMINO_USER_NAME_KEY_NAME)
+    assert (
+        user
+    ), f"User must be specified by {DOMINO_USER_NAME_KEY_NAME} environment variable."
+    assert (
+        host
+    ), f"Host must be specified by {DOMINO_HOST_KEY_NAME} environment variable."
+
+    domino_client = Domino(host=host, project=f"{user}/quick-start")
+
+    env_list = domino_client.environments_list()
+
+    for env in env_list["data"]:
+        if "Spark Cluster Environment" in env["name"]:
             return env["id"]
 
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -2,7 +2,7 @@
 To run these tests you need to have at least configured airflow in
 local mode and run:
 
-`airflow initdb`
+`airflow db init`
 """
 import os
 from datetime import datetime
@@ -17,6 +17,7 @@ from airflow.models import TaskInstance
 
 
 TEST_PROJECT = os.environ.get("DOMINO_TEST_PROJECT")
+dag_id = "test_operator"
 
 
 def test_airflow_dags():
@@ -27,10 +28,10 @@ def test_airflow_dags():
 
     start_time = datetime.now()
 
-    dag = DAG(dag_id="airflow_dag_test_0", start_date=start_time)
+    dag = DAG(dag_id, start_date=start_time)
     task = DummyOperator(
         dag=dag,
-        task_id='run_this_last',
+        task_id='test_airflow_dags',
     )
 
     task.run()
@@ -41,10 +42,10 @@ def test_airflow_dags():
 def test_operator():
     start_time = datetime.now()
 
-    dag = DAG(dag_id="foo", start_date=start_time)
+    dag = DAG(dag_id, start_date=start_time)
     task = DominoOperator(
         dag=dag,
-        task_id="foo",
+        task_id="test_operator",
         project=TEST_PROJECT,
         isDirect=True,
         command=["python -V"],
@@ -58,10 +59,10 @@ def test_operator():
 def test_operator_fail(caplog):
     execution_dt = datetime.now()
 
-    dag = DAG(dag_id="foo", start_date=execution_dt)
+    dag = DAG(dag_id, start_date=execution_dt)
     task = DominoOperator(
         dag=dag,
-        task_id="foo",
+        task_id="test_operator_fail",
         project=TEST_PROJECT,
         isDirect=True,
         command=["python -c 'import sys; sys.exit(1)'"],
@@ -76,10 +77,10 @@ def test_operator_fail(caplog):
 def test_operator_fail_invalid_tier(caplog):
     execution_dt = datetime.now()
 
-    dag = DAG(dag_id="foo", start_date=execution_dt)
+    dag = DAG(dag_id, start_date=execution_dt)
     task = DominoOperator(
         dag=dag,
-        task_id="foo",
+        task_id="test_operator_fail_invalid_tier",
         project=TEST_PROJECT,
         isDirect=True,
         command=["python -V"],


### PR DESCRIPTION
### Link to JIRA
[DOM-43066](https://dominodatalab.atlassian.net/browse/DOM-43066)

### What issue does this pull request solve?
- https://github.com/dominodatalab/python-domino/issues/153
- DominoSparkOperator not fully usable with python 3.7 due to min requirements

### What is the solution?
- fix bugs in test
- set python minimum requirements to 3.7

### Testing
- Updated unit test
- setup new python environment with 3.7 `pipenv install --python 3.7` and install and test python-domino

- [x] Unit test(s)

### Pull Request Reminders

- [x] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [x] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
