### PR TITLE
Replace bs4 with beautifulsoup4 in `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.7.0',
-    install_requires=["packaging", "requests>=2.4.2", "bs4==0.*,>=0.0.1", "polling2~=0.5.0",
+    install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.7.0',
-    install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4", "polling2~=0.5.0",
+    install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],


### PR DESCRIPTION
### Link to JIRA

There is no JIRA ticket associated to this change.

### What issue does this pull request solve?

There is a bug in the `setup.py` of this package, where it expects `bs4` to be installed. The correct package would be [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/). [`bs4`](https://pypi.org/project/bs4) is a dummy package on PyPI that install `beautifulsoup4`, albeit I'm unsure which version. The confusion arises from the fact that the import namespace of `beautifulsoup4` is `bs4` (e.g. `from bs4 import BeautifulSoup`).

I would appreciate it if you could merge this quickly and release a new patch version, as this is blocking me from putting `dominodatalab` on [Conda-Forge](https://github.com/conda-forge/staged-recipes/pull/22310).


### What is the solution?

The solution is to replace `bs4` with `beautifulsoup4` in the `setup.py`.

### Testing

I don't think this change requires exhaustive testing.

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
