### PR TITLE
Update Model API Create with logHttpRequestResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Updated Model API to support for `logHttpRequestResponse`
 
 ## 1.2.2
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -357,7 +357,7 @@ class Domino:
         :param compute_cluster_properties:          dict (Optional)
                                                     The compute cluster properties definition contains parameters for
                                                     launching any Domino supported compute cluster for a job. Use this
-                                                    to launch a job that uses compute cluster instead of
+                                                    to launch a job that uses a compute cluster instead of
                                                     the deprecated on_demand_spark_cluster_properties field. If
                                                     on_demand_spark_cluster_properties and compute_cluster_properties
                                                     are both present, on_demand_spark_cluster_properties will be ignored.
@@ -918,7 +918,7 @@ class Domino:
         return self._get(url)
 
     def model_publish(
-        self, file, function, environment_id, name, description, files_to_exclude=None
+        self, file, function, environment_id, name, description, logHttpRequestResponse, files_to_exclude=None
     ):
         if files_to_exclude is None:
             files_to_exclude = []
@@ -932,6 +932,7 @@ class Domino:
             "function": function,
             "excludeFiles": files_to_exclude,
             "environmentId": environment_id,
+            "logHttpRequestResponse": logHttpRequestResponse
         }
 
         response = self.request_manager.post(url, json=request)

--- a/examples/models_and_environments.py
+++ b/examples/models_and_environments.py
@@ -40,6 +40,7 @@ published_model = domino.model_publish(
     environment_id=chosen_environment_id,
     name="Model published from API!",
     description="v1",
+    logHttpRequestResponse="true",
 )
 published_model_id = published_model.get("data", {}).get("_id")
 print("Model {} published, details below:".format(published_model_id))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,9 +33,10 @@ def test_publish_a_model(default_domino_client):
     env_id = ""
     model_name = "Model Name"
     model_description = "Model Description"
+    log_http_request_response = "true"
 
     model = default_domino_client.model_publish(
-        filename, function, env_id, model_name, model_description
+        filename, function, env_id, model_name, model_description, log_http_request_response
     )
 
     assert model["data"]["name"] == model_name


### PR DESCRIPTION
### Link to JIRA

[[DOM-XYZ](https://dominodatalab.atlassian.net/browse)](https://onedominodatalab.atlassian.net/browse/PS-6544)

### What issue does this pull request solve?

Currently, Python API does not support enabling Model API HTTP request and response logging.

### What is the solution?

Introduce enabling Model API HTTP requests and responses via the python library.

### Testing

I have tested this by enabling the Log HTTP Request and responses with Pythion code. Then issue curl commands and observe the requests and responses are logged 
- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)