### PR TITLE
Deprecate blobs_get and open blobs_get_v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to the `python-domino` library will be documented in this fi
 ## [Unreleased]
 ### Added
 * Updated Apps documentation
+* Added get_blobs_v2 endpoint plus tests
 
 ### Changed
+* Marked get_blobs endpoint as deprecated
 
 ## 1.2.4
 

--- a/README.adoc
+++ b/README.adoc
@@ -481,10 +481,10 @@ print file['path'], '->', file['url']
 print(files)
 
 # Get the content (i.e. blob) for the file you're interested in.
-# blobs_get returns a connection rather than the content, because
+# blobs_get_v2 returns a connection rather than the content, because
 # the content can get quite large and it's up to you how you want
 # to handle it
-print(domino.blobs_get(files[0]['key']).read())
+print(domino.blobs_get_v2(files[0]['path'], commitId, domino.project_id).read())
 
 # Start a run of file main.py using the latest copy of that file
 domino.runs_start(["main.py", "arg1", "arg2"])

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1219,11 +1219,21 @@ class Domino:
 
     @staticmethod
     def _validate_blob_path(path):
-        pattern = r"(^|\/)\.\.($|\/)"
-        if re.search(pattern, path):
-            raise Exception(
+        """
+        Helper method to validate that the path is normalized
+        For example: A//B, A/B/, A/./B and A/foo/../B are not normalized/canonical, whereas A/B is.
+
+        Args:
+            path: the string of the path to check
+
+        Return:
+           None, however, it throws a MalformedInputException if the input is not normalized/canonical.
+        """
+        normalized_path = os.path.normpath(path)
+        if path != normalized_path:
+            raise exceptions.MalformedInputException(
                 (
-                    "Path should be canonical and cannot contain "
+                    "Path should be normalized and cannot contain "
                     "'..' or '../'. "
                 )
             )

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -4,6 +4,7 @@ import os
 import re
 import time
 from typing import List, Optional, Tuple
+import warnings
 
 import polling2
 import requests
@@ -689,6 +690,9 @@ class Domino:
         :param key: blob key
         :return: blob content
         """
+        message = "blobs_get is deprecated and will soon be removed. Please migrate to blobs_get_v2 and adjust the " \
+                  "input parameters accordingly "
+        warnings.warn(message, DeprecationWarning)
         self._validate_blob_key(key)
         url = self._routes.blobs_get(key)
         return self.request_manager.get_raw(url)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -684,8 +684,18 @@ class Domino:
         return self._put_file(url, file)
 
     def blobs_get(self, key):
+        """
+        Deprecated. Use blobs_get_v2(path, commit_id, project_id) instead
+        :param key: blob key
+        :return: blob content
+        """
         self._validate_blob_key(key)
         url = self._routes.blobs_get(key)
+        return self.request_manager.get_raw(url)
+
+    def blobs_get_v2(self, path, commit_id, project_id):
+        self._validate_blob_path(path)
+        url = self._routes.blobs_get_v2(path, commit_id, project_id)
         return self.request_manager.get_raw(url)
 
     def fork_project(self, target_name):
@@ -1200,6 +1210,17 @@ class Domino:
                     "Perhaps you passed a file path on accident? "
                     "If you have a file path and want to get the "
                     "file, use files_list to get the blob key."
+                )
+            )
+
+    @staticmethod
+    def _validate_blob_path(path):
+        pattern = r"(^|\/)\.\.($|\/)"
+        if re.search(pattern, path):
+            raise Exception(
+                (
+                    "Path should be canonical and cannot contain "
+                    "'..' or '../'. "
                 )
             )
 

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -1,3 +1,5 @@
+import warnings
+
 class _Routes:
     def __init__(self, host, owner_username, project_name):
         self.host = host
@@ -73,6 +75,9 @@ class _Routes:
 
     # Deprecated - use blobs_get_v2 instead
     def blobs_get(self, key):
+        message = "blobs_get is deprecated and will soon be removed. Please migrate to blobs_get_v2 and adjust the " \
+                  "input parameters accordingly "
+        warnings.warn(message, DeprecationWarning)
         return self._build_project_url() + "/blobs/" + key
 
     def blobs_get_v2(self, path, commit_id, project_id):

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -81,7 +81,7 @@ class _Routes:
         return self._build_project_url() + "/blobs/" + key
 
     def blobs_get_v2(self, path, commit_id, project_id):
-        return self.host + f"/api/projects/beta/projects/{project_id}/files/{commit_id}/{path}/content"
+        return self.host + f"/api/projects/v1/projects/{project_id}/files/{commit_id}/{path}/content"
 
     def fork_project(self, project_id):
         return self.host + f"/v4/projects/{project_id}/fork"

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -71,8 +71,12 @@ class _Routes:
     def commits_list(self):
         return self._build_project_url() + "/commits"
 
+    # Deprecated - use blobs_get_v2 instead
     def blobs_get(self, key):
         return self._build_project_url() + "/blobs/" + key
+
+    def blobs_get_v2(self, path, commit_id, project_id):
+        return self.host + f"/api/projects/beta/projects/{project_id}/files/{commit_id}/{path}/content"
 
     def fork_project(self, project_id):
         return self.host + f"/v4/projects/{project_id}/fork"

--- a/examples/upload_and_run_file_and_download_results.py
+++ b/examples/upload_and_run_file_and_download_results.py
@@ -69,7 +69,7 @@ def download_results(domino, commitId, results, output, exp):
         output = ""
 
     for d in download:
-        url = domino.blobs_get(d["key"])
+        url = domino.blobs_get_v2(d["path"], commitId, domino.project_id)
         file_to_write = ""
 
         # if we have multiple files, then output is a directory

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -133,8 +133,7 @@ def test_get_file_from_a_project_v2(default_domino_client):
 
     for file in files_list["data"]:
         if file["path"] == ".dominoignore":
-            decompressed_data = gzip.decompress(default_domino_client.blobs_get_v2(file["path"], commits_list[0], default_domino_client.project_id).read())
-            file_contents = decompressed_data.decode('utf-8')
+            file_contents = default_domino_client.blobs_get_v2(file["path"], commits_list[0], default_domino_client.project_id).read()
             break
 
     assert "ignore certain files" in str(

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -4,7 +4,7 @@ from pprint import pformat
 import gzip
 import pytest
 
-from domino import Domino
+from domino import Domino, exceptions
 from domino.exceptions import ProjectNotFoundException
 from domino.helpers import domino_is_reachable
 
@@ -139,6 +139,20 @@ def test_get_file_from_a_project_v2(default_domino_client):
     assert "ignore certain files" in str(
         file_contents
     ), f"Unable to get .dominoignore file\n{str(file_contents)}"
+
+
+@pytest.mark.skipif(
+    not domino_is_reachable(), reason="No access to a live Domino deployment"
+)
+def test_get_blobs_v2_non_canonical(default_domino_client):
+    """
+    Confirm that the python-domino client get_blobs_v2 will fail if input path is non-canonical
+    """
+    non_canonical_path = "/domino/mnt/../test.py"
+    commits_list = default_domino_client.commits_list()
+
+    with pytest.raises(exceptions.MalformedInputException):
+        default_domino_client.blobs_get_v2(non_canonical_path, commits_list[0], default_domino_client.project_id).read()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
### Link to JIRA

[DOM-51572](https://dominodatalab.atlassian.net/browse)

### What issue does this pull request solve?

blobs_get needs to be deprecated in favor of a more secure endpoint. This will not need to go in 5.9 - so the PR will stay open for some time.

### What is the solution?

deprecate it and add new endpoint!

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [x] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
