### PR TITLE
Add DominoJobTask as installable package

### DIFF
--- a/domino/flyte/__init__.py
+++ b/domino/flyte/__init__.py
@@ -1,0 +1,1 @@
+from domino.flyte.task import DominoJobConfig, DominoJobTask

--- a/domino/flyte/task.py
+++ b/domino/flyte/task.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, Optional, Type, Tuple
+from datetime import timedelta
+from dataclasses import dataclass
+from flytekit.configuration import SerializationSettings
+from flytekit.core.base_task import PythonTask, TaskMetadata
+from flytekit.core.interface import Interface
+from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
+
+
+@dataclass
+class DominoJobConfig(object):
+    ### Auth ###
+    Username: str
+    ProjectName: str
+    ApiKey: str
+    ### Job Config ###
+    Command: str
+    Title: Optional[str] = None
+    CommitId: Optional[str] = None
+    HardwareTierId: Optional[str] = None
+    EnvironmentId: Optional[str] = None
+    ComputeClusterProperties: Optional[Dict[str, str]] = None  # TODO: We probably need a better type here to pass it to the agent
+    ExternalVolumeMounts: Optional[Tuple[str]] = None
+
+
+class DominoJobTask(AsyncAgentExecutorMixin, PythonTask[DominoJobConfig]):
+    def __init__(
+        self,
+        name: str,
+        task_config: DominoJobConfig,
+        inputs: Optional[Dict[str, Type]] = None,
+        outputs: Optional[Dict[str, Type]] = None,
+        **kwargs,
+    ):        
+        super().__init__(
+            name=name,
+            task_type="domino_job",
+            task_config=task_config,
+            interface=Interface(),
+            inputs=inputs,
+            outputs=outputs,
+            metadata=TaskMetadata(retries=0, timeout=timedelta(hours=3)),
+            **kwargs,
+        )
+
+
+    # This is used to surface DominoJobConfig values necessary to send the request    
+    def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
+        return {
+            "username": self._task_config.Username,
+            "projectName": self._task_config.ProjectName,
+            "apiKey": self._task_config.ApiKey,
+            "command": self._task_config.Command,
+            "title": self._task_config.Title,
+            "commitId": self._task_config.CommitId,
+            "hardwareTierId": self._task_config.HardwareTierId,
+            "environmentId": self._task_config.EnvironmentId,
+            "externalVolumeMounts": self.task_config.ExternalVolumeMounts,
+        }

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],
         "data": ["dominodatalab-data>=0.1.0"],
+        "flyte": ["flytekit>=1.10.2"],
         "dev": [
             "black==22.3.0",
             "flake8==4.0.1",


### PR DESCRIPTION
### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-52828

### What issue does this pull request solve?
We want to be able to create a Flyte task that launches a Domino job. Defining this task should be bundled with packages installed on the DSE to make it easy for users to leverage this flyte functionality.

### What is the solution?
Add a new extra module `flyte` to our `dominodatalab` package.

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
