### PR TITLE
[DOM-53368] - fix version checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 * Updated Apps documentation
 * Added get_blobs_v2 endpoint plus tests
+* Updated version checker
 
 ### Changed
 * Marked get_blobs endpoint as deprecated

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+from packaging import version
 import re
 import time
 from typing import List, Optional, Tuple
@@ -1254,10 +1255,9 @@ class Domino:
             )
 
     def requires_at_least(self, at_least_version):
-        if at_least_version > self._version:
+        if version.parse(at_least_version) > version.parse(self._version):
             raise Exception(
-                f"You need at least version {at_least_version} but your deployment \
-                            seems to be running {self._version}"
+                f"You need at least version {at_least_version} but your deployment seems to be running {self._version}"
             )
         return True
 

--- a/tests/test_domino.py
+++ b/tests/test_domino.py
@@ -1,0 +1,18 @@
+import pytest
+from domino import Domino
+
+
+def test_versioning(requests_mock, dummy_hostname):
+    """validates domino version checking is correct"""
+
+    # Mock a typical response from the jobs status API endpoint (GET)
+    requests_mock.get(f"{dummy_hostname}/version", json={"version": "5.10.0"})
+
+    dom = Domino(host=dummy_hostname, project="rand_user/rand_project", api_key="rand_api_key")
+
+    dep_version = dom.deployment_version().get("version")
+    assert dep_version == "5.10.0"
+    assert dom.requires_at_least("5.3.0")
+    with pytest.raises(Exception):
+        dom.requires_at_least("5.11.0")
+


### PR DESCRIPTION
### Link to JIRA

[DOM-53368](https://dominodatalab.atlassian.net/browse/DOM-53368)

### What issue does this pull request solve?

domino version checker is failing to correctly assert num-string with base less than 10

### What is the solution?

use package version

### Testing

- [x] Unit test(s)

### Pull Request Reminders

- [x] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [x] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
