### PR TITLE
need retry package in setup.py + no interactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 * Updated Apps documentation
 * Added get_blobs_v2 endpoint plus tests
+* Added datasets_upload_files endpoint plus tests
+* Updated Projects and Datasets documentation 
 
 ### Changed
 * Marked get_blobs endpoint as deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 * Updated Apps documentation
 * Added get_blobs_v2 endpoint plus tests
-* Added datasets_upload_files endpoint plus tests
-* Updated Projects and Datasets documentation 
 
 ### Changed
 * Marked get_blobs endpoint as deprecated

--- a/README.adoc
+++ b/README.adoc
@@ -459,8 +459,7 @@ Uploads a file or entire directory to a dataset.
 
 * _dataset_id:_ The dataset identifier.
 * _local_path_to_file_or_directory:_ The path to the file or directory in local machine.
-* _file_upload_setting:_ (Optional) The setting to resolve naming conflict, must be one of `Ignore`, `Rename`, `Overwrite` (default).
-* _interactive:_ (Optional) Boolean to enable or disable interactivity for upload settings (default: True).
+* _file_upload_setting:_ (Optional) The setting to resolve naming conflict, must be one of `Overwrite`, `Rename`, `Ignore` (default).
 * _max_workers:_ (Optional) The max amount of threads (default: 10).
 * _target_chunk_size:_ (Optional) The max chunk size for multipart upload (default: 8MB).
 * _target_relative_path:_ (Optional) The path on the dataset to upload the file or directory to. Note that the path must exist or the upload will fail.

--- a/README.md
+++ b/README.md
@@ -490,8 +490,7 @@ Uploads a file or entire directory to a dataset.
 
 -   *dataset_id:* The dataset identifier.
 -   *local_path_to_file_or_directory:* The path to the file or directory in local machine.
--   *file_upload_setting:* The setting to resolve naming conflict, must be one of `Ignore`, `Rename`, `Overwrite` (default).
--   *interactive:* Boolean to enable or disable interactivity for upload settings (default: True).
+-   *file_upload_setting:* The setting to resolve naming conflict, must be one of `Overwrite`, `Rename`, `Ignore` (default).
 -   *max_workers:* The max amount of threads (default: 10).
 -   *target_chunk_size:* The max chunk size for multipart upload (default: 8MB).
 -   *target_relative_path:* The path on the dataset to upload the file or directory to. Note that the path must exist or the upload will fail.

--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -12,7 +12,7 @@ from retry import retry
 from domino.http_request_manager import _HttpRequestManager
 from domino.routes import _Routes
 
-FILE_UPLOAD_SETTING_DEFAULT = "Overwrite"
+FILE_UPLOAD_SETTING_DEFAULT = "Ignore"
 MAX_WORKERS = 10
 MAX_UPLOAD_ATTEMPTS = 10
 MB = 2 ** 20  # 2^20 bytes - 1 Megabyte

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             "pyspark==3.3.0",
             "pytest==6.2.2",
             "requests_mock==1.9.3",
+            "retry==0.9.2",
             "tox==3.25.1",
             "frozendict==2.3.4",
         ],

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,4 @@
 import random
-from unittest.mock import patch
 
 import pytest
 
@@ -76,7 +75,6 @@ def test_datasets_update_details_and_name(default_domino_client, random_seq):
     not domino_is_reachable(), reason="No access to a live Domino deployment"
 )
 def test_datasets_details(default_domino_client, random_seq):
-
     new_dataset_name = "My-New-Integration-Test-Dataset-3" + random_seq
     new_dataset_description = "My New Integration Test Dataset Description 4"
 
@@ -103,9 +101,10 @@ def test_datasets_upload(default_domino_client):
         1
     ]
     local_path_to_file = "test_datasets.py"
-    response = default_domino_client.datasets_upload_files(datasets_id, local_path_to_file, interactive=False)
+    response = default_domino_client.datasets_upload_files(datasets_id, local_path_to_file)
 
     assert "test_datasets.py" in response
+
 
 @pytest.mark.skipif(
     not domino_is_reachable(), reason="No access to a live Domino deployment"
@@ -116,9 +115,10 @@ def test_datasets_upload_with_sub_dir(default_domino_client):
     ]
     local_path_to_file = "test_datasets.py"
     response = default_domino_client.datasets_upload_files(datasets_id, local_path_to_file,
-                                                           target_relative_path="sub_d", interactive=False)
+                                                           target_relative_path="sub_d")
 
     assert "test_datasets.py" in response
+
 
 @pytest.mark.skipif(
     not domino_is_reachable(), reason="No access to a live Domino deployment"
@@ -129,38 +129,11 @@ def test_datasets_upload_non_existing_file(default_domino_client):
     ]
     local_path_to_file = "non_existing_file.py"
     try:
-        default_domino_client.datasets_upload_files(datasets_id, local_path_to_file, interactive=False)
+        default_domino_client.datasets_upload_files(datasets_id, local_path_to_file)
         assert False
     except ValueError:
         assert True
 
-@pytest.mark.skipif(
-    not domino_is_reachable(), reason="No access to a live Domino deployment"
-)
-def test_datasets_upload_interactivity(default_domino_client):
-    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
-        1
-    ]
-    local_path_to_file = "test_datasets.py"
-    with patch('builtins.input', return_value="Y"):
-        response = default_domino_client.datasets_upload_files(datasets_id, local_path_to_file, interactive=True)
-
-        assert "test_datasets.py" in response
-
-@pytest.mark.skipif(
-    not domino_is_reachable(), reason="No access to a live Domino deployment"
-)
-def test_datasets_upload_interactivity_error(default_domino_client):
-    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
-        1
-    ]
-    local_path_to_file = "test_datasets.py"
-    with patch('builtins.input', return_value="N"):
-        try:
-            default_domino_client.datasets_upload_files(datasets_id, local_path_to_file, interactive=True)
-            assert False
-        except InterruptedError:
-            assert True
 
 @pytest.mark.skipif(
     not domino_is_reachable(), reason="No access to a live Domino deployment"


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-53784 + revert of interactive part + more thorough docstrings

### What issue does this pull request solve?

Retry in setup.py

### What is the solution?

Add it

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
