### PR TITLE
[DOM-52828] Add interface vals to the domino task

### DIFF
--- a/domino/flyte/task.py
+++ b/domino/flyte/task.py
@@ -82,11 +82,6 @@ class DominoJobConfig(object):
     ComputeClusterProperties: Optional[ClusterProperties] = None
     VolumeSizeGiB: Optional[float] = None
     ExternalVolumeMountIds: Optional[List[str]] = None
-    # we want to provide the following to the flyte agent, but these are set by the DominoJobTask constructor 
-    # and so would never be expected to be passed into a DominoJobConfig constructor by a user.
-    # they are included here for completeness documenting what task config values are sent to/read by the flyte agent.
-    _InputInterfaceBase64: Optional[str] = None
-    _InputOutputInterfaceBase64: Optional[str] = None
 
     def toJson(self) -> Dict[str, Any]:
         return {
@@ -165,8 +160,6 @@ class DominoJobTask(AsyncAgentExecutorMixin, PythonTask[DominoJobConfig]):
             resolved_job_config["apiKey"] = domino_job_config.ApiKey
             resolved_job_config["command"] = domino_job_config.Command
             resolved_job_config["title"] = domino_job_config.Title
-            resolved_job_config["inputInterfaceBase64"] = None
-            resolved_job_config["inputOutputInterfaceBase64"] = None
 
             return resolved_job_config            
         else:

--- a/domino/flyte/task.py
+++ b/domino/flyte/task.py
@@ -140,7 +140,7 @@ class DominoJobTask(AsyncAgentExecutorMixin, PythonTask[DominoJobConfig]):
             InputInterfaceBase64=base64.b64encode(serialized_input_interface),
             InputOutputInterfaceBase64=base64.b64encode(serialized_input_output_interface),
         )
-        domino_job_config.PipelineConfig = pipelineConfig
+        task.task_config.PipelineConfig = pipelineConfig
 
         return task
 


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-52824

### What issue does this pull request solve?

Flyte input downloader init container and output uploader sidecar container need the interfaces for the input/output provided as args to their container commands in base64 string encoded format.

### What is the solution?

After instantiating the DominoTask, serialize the tasks input/output interfaces to base64 string and provide those as job config so they can be sent along to the job api by the flyte agent.

### Testing

Tested the serialized args produced from the python code with an arbitrary domino job that uses the init and sidecar containers, and placed data matching the interface at the expected input location in s3. Init sidecar downloaded the data, the code used the data and saved to the local output dir, then the sidecar successfully uploaded the output to s3.

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
