### PR TITLE
[DOM-54635] - updated requests session with retry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# Default owners for everything in the repo.
-
-*               @dominodatalab/amg
+*               @dominodatalab/eng-idsm 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Link to JIRA
 
-[DOM-XYZ](https://dominodatalab.atlassian.net/browse)
+[DOM-XYZ](https://dominodatalab.atlassian.net/browse/DOM-XYZ)
 
 ### What issue does this pull request solve?
 
@@ -20,9 +20,9 @@ _e.g. "I ran an upgrade from 4.2 to 4.6"._
 
 ### Pull Request Reminders
 
+- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
 - [ ] Has relevant documentation been updated?
 - [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
-- [ ] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
 - [ ] Are the existing unit tests still passing?
 - [ ] Have new unit tests been added to cover any changes to the code?
 - [ ] Has the JIRA ticket(s) been linked above?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Updated request with retry to avoid long down time during Gateway timeout or pool connection drops
 
 ## 1.3.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -141,6 +141,14 @@ You can change the log level by setting `DOMINO_LOG_LEVEL`, for example to `DEBU
 For testing purposes and issues with SSL certificates, set `DOMINO_VERIFY_CERTIFICATE` to `false`.
 Be sure to unset this variable when not in use.
 
+
+
+* `DOMINO_MAX_RETRIES`
++
+Default Retry is set to 4 
+Determines the number of attempts for the request session in case of a ConnectionError
+https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry[Get more info on request max timeout/error durations based on Retry and backoff factors]
+
 == Methods
 
 === Projects

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ See
     For testing purposes and issues with SSL certificates, set `DOMINO_VERIFY_CERTIFICATE` to `false`. 
     Be sure to unset this variable when not in use.
 
+- `DOMINO_MAX_RETRIES`
+    
+    Default Retry is set to 4 
+    Determines the number of attempts for the request session in case of a ConnectionError
+    Get more info on request max timeout/error durations based on Retry and backoff factors [here](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry)
+
 # Methods
 
 ## Projects

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -12,7 +12,7 @@ from .constants import DOMINO_VERIFY_CERTIFICATE
 from .exceptions import ReloginRequiredException
 
 
-DOMINO_API_RETRIES = 5
+R_SESSION_MAX_RETRIES = 4
 
 class _SessionInitializer:
     def __initialize__(self, session):
@@ -34,11 +34,11 @@ class _HttpRequestManager:
 
     def _set_session(self):
         """
-        Initialize a request session with retry.
+        Initialize a request session with retry to help manage connections drop.
         """
         self.session = requests.Session()
         retries = Retry(
-            total=DOMINO_API_RETRIES,
+            total=int(os.getenv("DOMINO_MAX_RETRIES", str(R_SESSION_MAX_RETRIES))),
             backoff_factor=1,  # retry seconds
             status_forcelist=[502, 503, 504],
         )

--- a/domino/http_request_manager.py
+++ b/domino/http_request_manager.py
@@ -40,7 +40,7 @@ class _HttpRequestManager:
         retries = Retry(
             total=int(os.getenv("DOMINO_MAX_RETRIES", str(R_SESSION_MAX_RETRIES))),
             backoff_factor=1,  # retry seconds
-            status_forcelist=[502, 503, 504],
+            status_forcelist=[408, 502, 503, 504],
         )
 
         if os.environ.get(DOMINO_VERIFY_CERTIFICATE, None) in ["false", "f", "n", "no"]:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     keywords=["Domino Data Lab", "API"],
-    python_requires='>=3.7.0',
+    python_requires='>=3.9.0',
     install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4.11", "polling2~=0.5.0",
                       "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2",
                       "retry==0.9.2"],

--- a/tests/test_basic_auth.py
+++ b/tests/test_basic_auth.py
@@ -34,11 +34,12 @@ def test_invalid_token_file_error():
     invalid_file = "non_existent_token_file.txt"
 
     with pytest.raises(FileNotFoundError):
-        Domino(
+        test_domino = Domino(
             host=dummy_host,
             project="anyuser/quick-start",
             domino_token_file=invalid_file,
         )
+        test_domino.runs_list()["data"]
 
 
 def test_malformed_project_input_error(caplog):
@@ -97,7 +98,7 @@ def test_object_creation_with_api_proxy():
     dummy_host = "http://domino.somefakecompany.com"
     dummy_api_proxy = "localhost:1234"
 
-    d = Domino(host=dummy_host, project="anyuser/quick-start", api_key=dummy_api_proxy)
+    d = Domino(host=dummy_host, project="anyuser/quick-start", api_proxy=dummy_api_proxy)
     assert isinstance(
         d.request_manager.auth, domino.authentication.ProxyAuth
     ), "Authentication using API proxy should be of type domino.authentication.ProxyAuth"
@@ -111,7 +112,7 @@ def test_object_creation_with_api_proxy_with_scheme():
     dummy_host = "http://domino.somefakecompany.com"
     dummy_api_proxy = "https://localhost:1234"
 
-    d = Domino(host=dummy_host, project="anyuser/quick-start", api_key=dummy_api_proxy)
+    d = Domino(host=dummy_host, project="anyuser/quick-start", api_proxy=dummy_api_proxy)
     assert isinstance(
         d.request_manager.auth, domino.authentication.ProxyAuth
     ), "Authentication using API proxy should be of type domino.authentication.ProxyAuth"

--- a/tests/test_domino.py
+++ b/tests/test_domino.py
@@ -33,8 +33,7 @@ def test_request_session():
      start_time = time.time()
      try:
          response = request_manager.request_session.get(
-             'https://httpbin.org/delay/10',
-             timeout=1
+             'https://localhost:9999' # ConnectionError
          )
      except Exception as ex:
          print('It failed :(', ex.__class__.__name__)
@@ -43,4 +42,4 @@ def test_request_session():
      finally:
          end_time = time.time()
          total_time = end_time - start_time
-         assert(total_time > 10) # actual value should be around 10.62....
+         assert(total_time > 5) # actual value should be around 6.0210....

--- a/tests/test_domino.py
+++ b/tests/test_domino.py
@@ -1,5 +1,17 @@
+import os
 import pytest
+import time
+from requests.auth import AuthBase
+
 from domino import Domino
+from domino.http_request_manager import _HttpRequestManager
+
+os.environ["DOMINO_MAX_RETRIES"] = "3"
+
+class TestAuth(AuthBase):
+     def __init__(self, *args, **kwargs):
+         super(TestAuth, self).__init__(*args, **kwargs)
+         self.header = None
 
 
 def test_versioning(requests_mock, dummy_hostname):
@@ -16,3 +28,19 @@ def test_versioning(requests_mock, dummy_hostname):
     with pytest.raises(Exception):
         dom.requires_at_least("5.11.0")
 
+def test_request_session():
+     request_manager = _HttpRequestManager(auth=TestAuth())
+     start_time = time.time()
+     try:
+         response = request_manager.request_session.get(
+             'https://httpbin.org/delay/10',
+             timeout=1
+         )
+     except Exception as ex:
+         print('It failed :(', ex.__class__.__name__)
+     else:
+         print('It eventually worked', response.status_code)
+     finally:
+         end_time = time.time()
+         total_time = end_time - start_time
+         assert(total_time > 10) # actual value should be around 10.62....


### PR DESCRIPTION
### Link to JIRA

[DOM-54635](https://dominodatalab.atlassian.net/browse/DOM-54635)

### What issue does this pull request solve?
Some long-running jobs are failing with ConnectionError due to connections being dropped.

### What is the solution?
We updated the request session with configurable retries to support connection timeouts, preventing long-running jobs from failing due to connection drops or long timeouts.

### Testing
- [x] Unit test(s)

### Pull Request Reminders

- [x] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Update the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md)
- [ ] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
