### PR TITLE
DOM-57187 - bump up typing-extensions version to solve conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* updated type-extensions dependency to 4.5.0
 
 ## 1.4.0
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.9.0',
     install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4.11", "polling2~=0.5.0",
-                      "urllib3~=1.26.12", "typing-extensions~=4.5.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2",
+                      "urllib3~=1.26.12", "typing-extensions>=4.5.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2",
                       "retry==0.9.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.9.0',
     install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4.11", "polling2~=0.5.0",
-                      "urllib3~=1.26.12", "typing-extensions~=4.4.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2",
+                      "urllib3~=1.26.12", "typing-extensions~=4.5.0", "frozendict~=2.3.4", "python-dateutil~=2.8.2",
                       "retry==0.9.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-57187

### What issue does this pull request solve?

Solve the dependency conflicts in DSEs

### What is the solution?

bump up the version of type-extensions.

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [x] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [x] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?

### References (optional)
