### PR TITLE
[DOM-58567] Datasets Snapshot File Upload: Handle Windows-style Paths

### DIFF
--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -37,20 +37,19 @@ class UploadChunk:
 
 class Uploader:
     def __init__(
-            self,
-            csrf_no_check_header: {str, str},
-            dataset_id: str,
-            local_path_to_file_or_directory: str,
-            log: Logger,
-            request_manager: _HttpRequestManager,
-            routes: _Routes,
-            target_relative_path: str,
+        self,
+        csrf_no_check_header: {str, str},
+        dataset_id: str,
+        local_path_to_file_or_directory: str,
+        log: Logger,
+        request_manager: _HttpRequestManager,
+        routes: _Routes,
+        target_relative_path: str,
 
-            file_upload_setting: str,
-            max_workers: int,
-            target_chunk_size: int,
-            interrupted: bool = False
-
+        file_upload_setting: str,
+        max_workers: int,
+        target_chunk_size: int,
+        interrupted: bool = False
     ):
         self.csrf_no_check_header = csrf_no_check_header
         self.dataset_id = dataset_id

--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -51,9 +51,14 @@ class Uploader:
         target_chunk_size: int,
         interrupted: bool = False
     ):
+        # Transforms Windows-style paths to Unix-style paths, which the start upload API expects
+        cleaned_relative_local_path = os.path.relpath(os.path.normpath(local_path_to_file_or_directory), start=os.curdir)
+        if os.sep != '/':
+            cleaned_relative_local_path = cleaned_relative_local_path.replace(os.sep, '/')        
+
         self.csrf_no_check_header = csrf_no_check_header
         self.dataset_id = dataset_id
-        self.local_path_file_or_directory = os.path.relpath(local_path_to_file_or_directory, start=os.curdir)
+        self.local_path_file_or_directory = cleaned_relative_local_path
         self.log = log
         self.request_manager = request_manager
         self.routes = routes

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -126,6 +126,22 @@ def test_datasets_upload_with_sub_dir(default_domino_client):
     not domino_is_reachable(), reason="No access to a live Domino deployment"
 )
 @patch('os.path.exists')
+def test_datasets_upload_mixed_slash_path(mock_exists, default_domino_client):
+    # Simulating windows style-path for an existent file
+    mock_exists.return_value = True
+    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
+        0
+    ]
+    local_path_to_file = "tests/assets/back\slash.txt"
+    response  = default_domino_client.datasets_upload_files(datasets_id, 
+                                                            local_path_to_file)
+    assert "back\slash.txt" in response
+
+
+@pytest.mark.skipif(
+    not domino_is_reachable(), reason="No access to a live Domino deployment"
+)
+@patch('os.path.exists')
 def test_datasets_upload_windows_path(mock_exists, default_domino_client):
     # Simulating windows style-path for an existent file
     mock_exists.return_value = True

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ import random
 import pytest
 
 from domino.helpers import domino_is_reachable
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -117,6 +118,40 @@ def test_datasets_upload_with_sub_dir(default_domino_client):
     assert "test_datasets.py" in os.listdir("tests")
     local_path_to_file = "tests/test_datasets.py"
     response = default_domino_client.datasets_upload_files(datasets_id, local_path_to_file,
+                                                           target_relative_path="sub_d")
+    assert "test_datasets.py" in response
+
+
+@pytest.mark.skipif(
+    not domino_is_reachable(), reason="No access to a live Domino deployment"
+)
+@patch('os.path.exists')
+def test_datasets_upload_windows_path(mock_exists, default_domino_client):
+    # Simulating windows style-path for an existent file
+    mock_exists.return_value = True
+    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
+        0
+    ]
+    windows_local_path_to_file = "tests\\test_datasets.py"
+    response  = default_domino_client.datasets_upload_files(datasets_id, 
+                                                            windows_local_path_to_file)
+    assert "test_datasets.py" in response
+
+
+@pytest.mark.skipif(
+    not domino_is_reachable(), reason="No access to a live Domino deployment"
+)
+@patch('os.path.exists')
+def test_datasets_upload_with_sub_dir_windows_path(mock_exists, default_domino_client):
+    # Simulating windows style-path for an existent file
+    mock_exists.return_value = True
+    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
+        0
+    ]
+    assert "test_datasets.py" in os.listdir("tests")
+    windows_local_path_to_file = "tests\\test_datasets.py"
+    response = default_domino_client.datasets_upload_files(datasets_id, 
+                                                           windows_local_path_to_file,
                                                            target_relative_path="sub_d")
 
     assert "test_datasets.py" in response


### PR DESCRIPTION
### Link to JIRA

[DOM-58567](https://dominodatalab.atlassian.net/browse/DOM-58567)

### What issue does this pull request solve?

Uploading files to a Dataset on a windows can fail since the upload API expects a Unix-style filepath. The backslash will be interpreted as an escape character.

### What is the solution?

For running on windows, transform the path to 

### Testing

Tested `domino.datasets_upload_files` for a file located at "<path to test scrip>\test\test.txt" and added unit tests.

- [x] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?