### PR TITLE
[DOM-59086] Fix uploading Folder to Dataset on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `python-domino` library will be documented in this fi
 ### Added
 
 ### Changed
+* Fixed issue with using `datasets_upload_files` function to upload folders to a snapshot on Windows
 
 ## 1.4.2
 

--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -51,12 +51,9 @@ class Uploader:
         target_chunk_size: int,
         interrupted: bool = False
     ):
-        # when running on Windows, converts path to Unix-style path, which the upload chunk API expects
         cleaned_relative_local_path = os.path.relpath(os.path.normpath(local_path_to_file_or_directory), start=os.curdir)
-        if os.path.isdir(local_path_to_file_or_directory) and not cleaned_relative_local_path.endswith('/'):
-            cleaned_relative_local_path += '/'
-        if os.sep != '/':
-            cleaned_relative_local_path = cleaned_relative_local_path.replace(os.sep, '/')        
+        # in case running on windows
+        cleaned_relative_local_path = self._get_unix_style_path(cleaned_relative_local_path)        
 
         self.csrf_no_check_header = csrf_no_check_header
         self.dataset_id = dataset_id
@@ -133,8 +130,12 @@ class Uploader:
             for filename in filenames:
                 # construct the relative path for each file
                 relative_path_to_file = os.path.join(dirpath, filename)
+
+                # in case running on windows
+                cleaned_relative_path = self._get_unix_style_path(relative_path_to_file)
+                
                 # append chunk to queue
-                chunk_q.extend(self._create_chunks(relative_path_to_file))
+                chunk_q.extend(self._create_chunks(cleaned_relative_path))
         return chunk_q
 
     def _create_chunks(self, local_path_file, starting_index=1) -> list[UploadChunk]:
@@ -203,3 +204,9 @@ class Uploader:
                                                          chunk.total_chunks, chunk.identifier, chunk_checksum)
         # test chunk returns no content if it should upload
         return self.request_manager.get(test_chunk_url).status_code == 204, chunk_checksum
+
+    def _get_unix_style_path(self, path: str) -> str:
+        # when running on Windows, converts path to Unix-style path, which the upload chunk API expects
+        if os.sep != '/':
+            path = path.replace(os.sep, '/')
+        return path

--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -51,8 +51,10 @@ class Uploader:
         target_chunk_size: int,
         interrupted: bool = False
     ):
-        # When running on Windows, converts paths to Unix-style paths, which the upload chunk API expects
+        # when running on Windows, converts path to Unix-style path, which the upload chunk API expects
         cleaned_relative_local_path = os.path.relpath(os.path.normpath(local_path_to_file_or_directory), start=os.curdir)
+        if os.path.isdir(local_path_to_file_or_directory) and not cleaned_relative_local_path.endswith('/'):
+            cleaned_relative_local_path += '/'
         if os.sep != '/':
             cleaned_relative_local_path = cleaned_relative_local_path.replace(os.sep, '/')        
 

--- a/tests/assets/back\slash.txt
+++ b/tests/assets/back\slash.txt
@@ -1,0 +1,1 @@
+back slash sample content

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -179,6 +179,23 @@ def test_datasets_upload_with_sub_dir_windows_path(mock_exists, default_domino_c
 @pytest.mark.skipif(
     not domino_is_reachable(), reason="No access to a live Domino deployment"
 )
+@patch('os.path.exists')
+def test_datasets_upload_directory_windows_path(mock_exists, default_domino_client):
+    # Simulating windows style-path for an existent file
+    mock_exists.return_value = True
+    datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
+        0
+    ]
+    assert os.path.isdir("tests/assets")
+    windows_local_path_to_dir = "tests/assets"
+    response  = default_domino_client.datasets_upload_files(datasets_id, 
+                                                            windows_local_path_to_dir)
+    assert "tests/assets" in response
+
+
+@pytest.mark.skipif(
+    not domino_is_reachable(), reason="No access to a live Domino deployment"
+)
 def test_datasets_upload_non_existing_file(default_domino_client):
     datasets_id = default_domino_client.datasets_ids(default_domino_client.project_id)[
         1


### PR DESCRIPTION
### Link to JIRA

[DOM-59086](https://dominodatalab.atlassian.net/browse/DOM-59086)

### What issue does this pull request solve?

On Windows machines, filepaths contain `\` separators whereas the upload endpoint expects Unix-style `/` separators. This results in files not being uploaded properly on Windows. This is fixed for upload files (PR: https://github.com/dominodatalab/python-domino/pull/203). But the issue remains for uploading folders.

### What is the solution?

Replace Windows-style separators with Unix-style ones when uploading content from a folder.

### Testing

Created unit test and manual test for uploading a non-empty folder on a Windows machine to a Dataset. 

### Pull Request Reminders

- [x] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [x] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [x] Are the existing unit tests still passing?
- [x] Have new unit tests been added to cover any changes to the code?
- [x] Has the JIRA ticket(s) been linked above?
