### PR TITLE
QE-17483 loosen urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3~=1.26.18
+urllib3>=1.26.19,<3
 pytest~=7.4.3
 polling2~=0.5.0
 requests~=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.9.0',
     install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4.11", "polling2~=0.5.0",
-                      "urllib3~=1.26.12", "typing-extensions>=4.5.0", "frozendict~=2.3", "python-dateutil~=2.8.2",
+                      "urllib3>=1.26.19,<3", "typing-extensions>=4.5.0", "frozendict~=2.3", "python-dateutil~=2.8.2",
                       "retry==0.9.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/QE-17483

### What issue does this pull request solve?

urllib3 is too tightly constrained

### What is the solution?

loosens the urllib3 version for compliance with openapi generated clients

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

- Tested locally
- Tested using CI (see ticket details)

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
