### PR TITLE
[PS-13958] - Extend options for listing jobs

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -621,7 +621,7 @@ class Domino:
                   project_id: str,
                   order_by: str = "number",
                   sort_by: str = "desc",
-                  page_size: int = 3,
+                  page_size = None,
                   page_no: int = 1,
                   show_archived: str = "false",
                   status: str = "all",

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -617,14 +617,28 @@ class Domino:
         response = self.request_manager.post(url, json=request)
         return response
 
-    def jobs_list(self, project_id: str, page_size=None):
+    def jobs_list(self,
+                  project_id: str,
+                  order_by: str = "number",
+                  sort_by: str = "desc",
+                  page_size: int = 3,
+                  page_no: int = 1,
+                  show_archived: str = "false",
+                  status: str = "all",
+                  tag: Optional[str] = None):
         """
         Lists job history for a given project_id
         :param project_id: The project to query
+        :param order_by: Field on which sort has to be applied– e.g. "title" (default "number")
+        :param sort_by: Sort "desc" (default) or "asc"
         :param page_size: The number of jobs to return (default: 3)
+        :param page_no: Page number to fetch (default: 1).
+        :param show_archived: Show archived jobs in results (default: false)
+        :param status: Status of jobs to fetch– e.g. "completed" (default: "all")
+        :param tag: Optional tag filter
         :return: The details
         """
-        url = self._routes.jobs_list(project_id, page_size)
+        url = self._routes.jobs_list(project_id, order_by, sort_by, page_size, page_no, show_archived, status, tag)
         return self._get(url)
 
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -621,7 +621,7 @@ class Domino:
                   project_id: str,
                   order_by: str = "number",
                   sort_by: str = "desc",
-                  page_size = None,
+                  page_size: Optional[int] = None,
                   page_no: int = 1,
                   show_archived: str = "false",
                   status: str = "all",

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -175,9 +175,24 @@ class _Routes:
     def job_stop(self):
         return f"{self.host}/v4/jobs/stop"
 
-    def jobs_list(self, project_id, page_size: Optional[str]):
-        page_size_query = f"&page_size={page_size}" if page_size else ""
-        return f"{self.host}/v4/jobs?projectId={project_id}{page_size_query}"
+    def jobs_list(self,
+                  project_id,
+                  order_by,
+                  sort_by,
+                  page_size,
+                  page_no,
+                  show_archived,
+                  status,
+                  tag):
+
+        order_by_query = f"&order_by={order_by}"
+        sort_by_query = f"&sort_by={sort_by}"
+        page_size_query = f"&page_size={page_size}"
+        page_no_query = f"&page_no={page_no}"
+        show_archived_query = "&show_archived=" + show_archived.lower()
+        status_from_query = "&status=" + status.lower()
+        tag_query = f"&tag={tag}" if tag else ""
+        return f"{self.host}/v4/jobs?projectId={project_id}{order_by_query}{sort_by_query}{page_size_query}{page_no_query}{show_archived_query}{status_from_query}{tag_query}"
 
     def job_status(self, job_id):
         return f"{self.host}/v4/jobs/{job_id}"

--- a/domino/routes.py
+++ b/domino/routes.py
@@ -187,7 +187,7 @@ class _Routes:
 
         order_by_query = f"&order_by={order_by}"
         sort_by_query = f"&sort_by={sort_by}"
-        page_size_query = f"&page_size={page_size}"
+        page_size_query = f"&page_size={page_size}" if page_size else ""
         page_no_query = f"&page_no={page_no}"
         show_archived_query = "&show_archived=" + show_archived.lower()
         status_from_query = "&status=" + status.lower()


### PR DESCRIPTION
### Link to JIRA

[PS-13958](https://onedominodatalab.atlassian.net/browse/PS-13958)

### What issue does this pull request solve?

Extends the query functionality of jobs_list() to include as many of the options available in Domino's REST API as possible.

### What is the solution?

Added additional arguments and set their default values to match those in the REST API.

### Testing

Tested by listing previous jobs in a project. As the function explicitly sends the default API values, it uses all of the query parameters by default.

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
