### PR TITLE
Pin typing-extensions to ~=4.13.0 where it is still compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ beautifulsoup4~=4.12.2
 packaging~=23.2
 retry~=0.9.2
 setuptools~=68.2.2
+typing-extensions~=4.13.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords=["Domino Data Lab", "API"],
     python_requires='>=3.9.0',
     install_requires=["packaging", "requests>=2.4.2", "beautifulsoup4~=4.11", "polling2~=0.5.0",
-                      "urllib3>=1.26.19,<3", "typing-extensions>=4.5.0", "frozendict~=2.3", "python-dateutil~=2.8.2",
+                      "urllib3>=1.26.19,<3", "typing-extensions~=4.13.0", "frozendict~=2.3", "python-dateutil~=2.8.2",
                       "retry==0.9.2"],
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],


### PR DESCRIPTION
### What issue does this pull request solve?

A new version of `typing-extensions` has been release [4.14.0](https://pypi.org/project/typing-extensions/4.14.0/) which breaks compatibility on some things that are internally used

### What is the solution?

Pin to latest working version `~=4.13.2` as a temporal patch - In order to jump to `4.14.0` we need to regenerate the API specs ([like this one](https://github.com/dominodatalab/python-domino/blob/master/domino/_impl/custommetrics/api_client.py#L1262-L1274))

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
