### PR TITLE
DOM-70889 DOM-70905  remove start time default and fix bug with filtering by run_id

### DIFF
--- a/domino/aisystems/tracing/tracing.py
+++ b/domino/aisystems/tracing/tracing.py
@@ -300,7 +300,8 @@ def search_traces(
 
     # get traces made within the time range
     # get traces with the trace names
-    filter_clauses = [time_range_filter_clause, trace_name_filter_clause]
+    run_filter_clause = f'metadata.mlflow.sourceRun = "{run_id}"'
+    filter_clauses = [run_filter_clause, time_range_filter_clause, trace_name_filter_clause]
     filter_string = ' AND '.join([x for x in filter_clauses if x])
 
     traces = client.search_traces(

--- a/domino/aisystems/tracing/tracing.py
+++ b/domino/aisystems/tracing/tracing.py
@@ -62,7 +62,7 @@ def _make_span_summary(span: mlflow.entities.Span) -> SpanSummary:
 
 def _do_evaluation(
         span: mlflow.entities.Span,
-        evaluator: OptionalEvaluator] = None,
+        evaluator: Optional[Evaluator] = None,
         is_production: bool = False) -> Optional[dict]:
 
         if not is_production and evaluator:
@@ -75,7 +75,7 @@ def _do_evaluation(
 
         return None
 
-def _log_eval_results(parent_span: mlflow.entities.Span, evaluator: OptionalEvaluator]):
+def _log_eval_results(parent_span: mlflow.entities.Span, evaluator: Optional[Evaluator]):
     """
     Saves the evaluation results
     """

--- a/domino/aisystems/tracing/tracing.py
+++ b/domino/aisystems/tracing/tracing.py
@@ -268,7 +268,7 @@ def search_traces(
     Args:
         run_id: string, the ID of the development mode evaluation run to search for traces.
         trace_name: optinoal, the name of the traces to search for
-        start_time: optional python datetime, defaults to 1 hour ago
+        start_time: optional python datetime
         end_time: optional python datetime, defaults to now
         page_token: optional page token for pagination. You can use this to request the next page of results and may
          find a page_token in the response of the previous search_traces call.
@@ -285,9 +285,14 @@ def search_traces(
 
     experiment_id = client.get_run(run_id).info.experiment_id
 
-    start_ms = _datetime_to_ms(start_time or datetime.now() - timedelta(hours=1))
-    end_ms = _datetime_to_ms(end_time or datetime.now())
-    time_range_filter_clause = f'timestamp_ms > {start_ms} AND timestamp_ms < {end_ms}'
+    time_range_filter_clause = ''
+    if start_time:
+        start_ms = _datetime_to_ms(start_time)
+        time_range_filter_clause += f'timestamp_ms > {start_ms}'
+
+    if end_time:
+        end_ms = _datetime_to_ms(end_time)
+        time_range_filter_clause += f' AND timestamp_ms < {end_ms}'
 
     trace_name_filter_clause = None
     if trace_name:

--- a/domino/aisystems/tracing/tracing.py
+++ b/domino/aisystems/tracing/tracing.py
@@ -63,7 +63,13 @@ def _do_evaluation(
         is_production: bool = False) -> Optional[dict]:
 
         if not is_production and evaluator:
-            return evaluator(span.inputs, span.outputs)
+            try:
+                return evaluator(span.inputs, span.outputs)
+            except Exception as e:
+                logging.error(
+                    "Inline evaluation failed for evaluator, %s. Error: %s" , evaluator.__name__, e, exc_info=True
+                )
+
         return None
 
 def _log_eval_results(parent_span: mlflow.entities.Span, evaluator: Optional[Callable[[Any, Any], dict[str, Any]]]):
@@ -99,7 +105,7 @@ def _set_span_inputs(parent_span, func, args, kwargs):
 def add_tracing(
         name: str,
         autolog_frameworks: Optional[list[str]] = [],
-        evaluator: Optional[Callable[[Any, Any], dict[str, Any]]] = None,
+        evaluator: Optional[Callable[[Any, Any], dict[str, int | float | str]]] = None,
         eagerly_evaluate_streamed_results: bool = True,
     ):
     """A decorator that starts an mlflow span for the function it decorates. If there is an existing trace

--- a/tests/integration/aisystems/test_aisystems_tracing.py
+++ b/tests/integration/aisystems/test_aisystems_tracing.py
@@ -407,6 +407,7 @@ def test_search_traces_multiple_runs_in_exp(setup_mlflow_tracking_server, mocker
         assert [trace.name for trace in res.data] == ["unit1"]
 
 
+
 def test_search_traces_pagination(setup_mlflow_tracking_server, mocker, mlflow, tracing, logging):
         """
         The api should provide a page token in if the total number of results is bigger than the max results


### PR DESCRIPTION
The search_traces API defaults to using a filter start time of 1 hour ago. This was intended to limit the amount of data pulled into memory when there are many traces.

However, this API is now paginated and we don’t let the user get all traces at once. This default is not necessary. It is also confusing, because users may try to retrieve traces that were created over an hour ago by not specifying a start time. this was the case in a recent bug bash.

This PR also fixes a bug where the run_id wasn't being used correctly as a filter. traces from all runs in the experiment would appear in the response in stead of just the specified run.

### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-70889
https://dominodatalab.atlassian.net/browse/DOM-70905

### What issue does this pull request solve?

_placeholder_

### What is the solution?

_placeholder_

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
