### PR TITLE
DOM-71264 Pin mlflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     extras_require={
         "airflow": ["apache-airflow==2.2.4"],
         "data": ["dominodatalab-data>=0.1.0"],
-        "aisystems": ["semver>=3.0.4", "pandas>=2.3.1", "numpy>=2.0.2", "mlflow-skinny>=3.2.0", "mlflow-tracing>=3.2.0"],
+        "aisystems": ["semver>=3.0.4", "pandas>=2.3.1", "numpy>=2.0.2", "mlflow-skinny==3.2.0", "mlflow-tracing==3.2.0"],
         "dev": [
             "pytest-order>=1.3.0",
             "pytest-asyncio>=0.23.8",


### PR DESCRIPTION
### Link to JIRA

https://dominodatalab.atlassian.net/browse/DOM-71264

we have had lots of trouble with mlflow pushing breaking chagnes into their sdk, we must pin the version that we install in the python-domino repo. for some reason it was not pinned

### What issue does this pull request solve?

_placeholder_

### What is the solution?

_placeholder_

### Testing

Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap, if any.

_e.g. "I ran an upgrade from 4.2 to 4.6"._

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
