### PR TITLE
Fixes NameError when calling app_publish

### DIFF
--- a/domino/domino.py
+++ b/domino/domino.py
@@ -955,7 +955,7 @@ class Domino:
             "environmentId": environmentId,
             "externalVolumeMountIds": externalVolumeMountIds
         }
-        omitting_null = {k: v for (k, v) in payload.items() if v is not None}
+        omitting_null = {k: v for (k, v) in request.items() if v is not None}
         response = self.request_manager.post(url, json=omitting_null)
         return response
 


### PR DESCRIPTION
### What issue does this pull request solve?

Calling app_publish()
line 958 where `payload` is referenced instead of `request`, causing a NameError. 

### What is the solution?

Update L958 to `request`