### PR TITLE
Added ability to start app on specic branch/commitRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the `python-domino` library will be documented in this fi
 ## [Unreleased]
 
 ### Added
+* Updated app_publish() to allow selecting branch/commitRef
+* Updated app_publish() to allow selecing specific app
 
 ### Changed
 

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -945,9 +945,9 @@ class Domino:
     def app_publish(self, unpublishRunningApps=True, hardwareTierId=None, environmentId=None, externalVolumeMountIds=None, commitId=None, branch=None, appId=None):
         if commitId and branch:
             raise ValueError("Only one of commitId or branch may be specified, not both.")
-        if unpublishRunningApps:
-            self.app_unpublish(appId=appId)
         app_id = appId or self._app_id
+        if unpublishRunningApps:
+            self.app_unpublish(appId=app_id)
         if app_id is None:
             # No App Exists creating one
             app_id = self.__app_create(hardware_tier_id=hardwareTierId)

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -942,25 +942,34 @@ class Domino:
         return response
 
     # App functions
-    def app_publish(self, unpublishRunningApps=True, hardwareTierId=None, environmentId=None, externalVolumeMountIds=None):
+    def app_publish(self, unpublishRunningApps=True, hardwareTierId=None, environmentId=None, externalVolumeMountIds=None, commitId=None, branch=None, appId=None):
+        if commitId and branch:
+            raise ValueError("Only one of commitId or branch may be specified, not both.")
         if unpublishRunningApps:
-            self.app_unpublish()
-        app_id = self._app_id
+            self.app_unpublish(appId=appId)
+        app_id = appId or self._app_id
         if app_id is None:
             # No App Exists creating one
             app_id = self.__app_create(hardware_tier_id=hardwareTierId)
         url = self._routes.app_start(app_id)
+        if commitId:
+            main_repo_git_ref = {"type": "commitId", "value": commitId}
+        elif branch:
+            main_repo_git_ref = {"type": "branches", "value": branch}
+        else:
+            main_repo_git_ref = None
         request = {
             "hardwareTierId": hardwareTierId,
             "environmentId": environmentId,
-            "externalVolumeMountIds": externalVolumeMountIds
+            "externalVolumeMountIds": externalVolumeMountIds,
+            "mainRepoGitRef": main_repo_git_ref,
         }
         omitting_null = {k: v for (k, v) in request.items() if v is not None}
         response = self.request_manager.post(url, json=omitting_null)
         return response
 
-    def app_unpublish(self):
-        app_id = self._app_id
+    def app_unpublish(self, appId=None):
+        app_id = appId or self._app_id
         if app_id is None:
             return
         status = self.__app_get_status(app_id)
@@ -971,10 +980,9 @@ class Domino:
             return response
 
     def __app_get_status(self, id) -> Optional[str]:
-        app_id = self._app_id
-        if app_id is None:
+        if id is None:
             return None
-        url = self._routes.app_get(app_id)
+        url = self._routes.app_get(id)
         response = self.request_manager.get(url).json()
         return response.get("status", None)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,148 @@
+import pytest
+
+from domino import Domino
+
+# Realistic mock IDs — 24-character hex MongoDB ObjectIds.
+MOCK_PROJECT_ID = "aabbccddeeff001122334454"
+MOCK_APP_ID = "aabbccddeeff001122334457"
+
+
+@pytest.fixture
+def mock_app_publish_setup(requests_mock, dummy_hostname):
+    """
+    Mocks all API calls that app_publish() depends on when an appId is provided.
+
+    If any dependent calls are added to app_publish or app_unpublish, they
+    must be mocked here as well.
+    """
+    requests_mock.get(f"{dummy_hostname}/version", json={"version": "9.9.9"})
+
+    # Mock app status lookup (GET) used by app_unpublish via __app_get_status
+    requests_mock.get(
+        f"{dummy_hostname}/v4/modelproducts/{MOCK_APP_ID}",
+        json={"id": MOCK_APP_ID, "status": "Running"},
+    )
+
+    # Mock app stop (POST) called by app_unpublish when app is running
+    requests_mock.post(
+        f"{dummy_hostname}/v4/modelproducts/{MOCK_APP_ID}/stop",
+        json={"id": MOCK_APP_ID, "status": "Stopped"},
+    )
+
+    # Mock app start (POST) — the main call made by app_publish
+    requests_mock.post(
+        f"{dummy_hostname}/v4/modelproducts/{MOCK_APP_ID}/start",
+        json={"id": MOCK_APP_ID, "status": "Running"},
+    )
+    yield
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_with_branch(requests_mock, dummy_hostname):
+    """
+    Confirm that the branch parameter is correctly formatted as mainRepoGitRef
+    in the app start request body.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID, branch="my-feature-branch")
+
+    app_start_request = next(
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/start"
+    )
+    assert app_start_request.json()["mainRepoGitRef"] == {
+        "type": "branches",
+        "value": "my-feature-branch",
+    }
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_with_commit_id(requests_mock, dummy_hostname):
+    """
+    Confirm that the commitId parameter is correctly formatted as mainRepoGitRef
+    in the app start request body.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID, commitId="abc123def456")
+
+    app_start_request = next(
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/start"
+    )
+    assert app_start_request.json()["mainRepoGitRef"] == {
+        "type": "commitId",
+        "value": "abc123def456",
+    }
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_omits_git_ref_when_not_provided(requests_mock, dummy_hostname):
+    """
+    Confirm that mainRepoGitRef is omitted from the request body when neither
+    branch nor commitId is provided.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID)
+
+    app_start_request = next(
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/start"
+    )
+    assert "mainRepoGitRef" not in app_start_request.json()
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_raises_if_both_branch_and_commit_id_provided(dummy_hostname):
+    """
+    Confirm that providing both branch and commitId raises a ValueError.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    with pytest.raises(ValueError, match="Only one of commitId or branch"):
+        d.app_publish(appId=MOCK_APP_ID, branch="my-branch", commitId="abc123")
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_unpublishes_running_app(requests_mock, dummy_hostname):
+    """
+    Confirm that app_publish calls stop on the running app before starting
+    when unpublishRunningApps=True (the default).
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID, unpublishRunningApps=True)
+
+    stop_requests = [
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/stop"
+    ]
+    assert len(stop_requests) == 1
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_skips_unpublish_when_disabled(requests_mock, dummy_hostname):
+    """
+    Confirm that app_publish does not call stop when unpublishRunningApps=False.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID, unpublishRunningApps=False)
+
+    stop_requests = [
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/stop"
+    ]
+    assert len(stop_requests) == 0
+
+
+@pytest.mark.usefixtures("clear_token_file_from_env", "mock_app_publish_setup")
+def test_app_publish_targets_specific_app_id(requests_mock, dummy_hostname):
+    """
+    Confirm that the provided appId is used in the start endpoint URL, not the
+    default first-app lookup.
+    """
+    d = Domino(host=dummy_hostname, project="anyuser/anyproject", api_key="whatever")
+    d.app_publish(appId=MOCK_APP_ID)
+
+    start_requests = [
+        req for req in requests_mock.request_history
+        if req.path == f"/v4/modelproducts/{MOCK_APP_ID}/start"
+    ]
+    assert len(start_requests) == 1


### PR DESCRIPTION
### Link to JIRA

[DOM-76463](https://dominodatalab.atlassian.net/browse/DOM-76463)

### What issue does this pull request solve?

Provide the ability to select a branch/commitRef when publishing an app. Also allows users to select the app, now that apps support more than one app.

### Testing

```
d = Domino(
    project=PROJECT,
    api_key=DOMINO_API_KEY,
    host=DOMINO_HOST,
)

# --- Test 1: publish on a specific branch ---
response = d.app_publish(
    branch="dev", appId="<app-id>"
)
print(response.status_code, response.json())

  # --- Test 2: publish at a specific commit ---
response = d.app_publish(
    commitId="c189caa3b05b65003af62c0103e20fe6008439b3",
    appId="<app-id>"
)
print(response.status_code, response.json())
```
Both return 200, and confirmed changed worked as desired in the UI.