### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+plans/
 .idea/
 dist/
 MANIFEST

--- a/domino/_custom_metrics.py
+++ b/domino/_custom_metrics.py
@@ -214,7 +214,6 @@ class _CustomMetricsClient(_CustomMetricsClientBase):
             "modelMonitoringId": model_monitoring_id,
             "metric": metric,
             "value": value,
-            "targetRange": {"condition": condition},
         }
         if condition:
             request["targetRange"] = {"condition": condition}

--- a/domino/datasets.py
+++ b/domino/datasets.py
@@ -96,7 +96,7 @@ class Uploader:
             self.request_manager.get(url)
             self.log.info("Upload session ended successfully.")
             return True
-        except:
+        except Exception:
             self.log.error("Ending snapshot upload failed. See error for details. Attempting to cancel "
                            "upload session.")
             self._cancel_upload_session()

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -136,6 +136,7 @@ class Domino:
             self._logger.info(
                 f" You need to log in to the Domino UI to start the run. Please do it at {self._routes.host}/relogin?redirectPath=/"
             )
+            raise
 
     def runs_start_blocking(
         self,
@@ -611,6 +612,7 @@ class Domino:
             self._logger.info(
                 f" You need to log in to the Domino UI to start the job. Please do it at {self._routes.host}/relogin?redirectPath=/"
             )
+            raise
 
     def job_stop(self, job_id: str, commit_results: bool = True):
         """

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1340,10 +1340,8 @@ class Domino:
         response = self.request_manager.delete(url)
         return response
 
-    def datasets_remove(self, dataset_ids: list):
-        for dataset_id in dataset_ids:
-            url = self._routes.datasets_details(dataset_id)
-            self.request_manager.delete(url)
+    def datasets_remove(self, dataset_ids: list) -> list:
+        return [self._dataset_remove(dataset_id) for dataset_id in dataset_ids]
 
     def datasets_upload_files(
         self,

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1982,6 +1982,9 @@ class Domino:
         response = self._get(url)
         if key in response.keys():
             return response[key]
+        raise exceptions.ProjectNotFoundException(
+            f"Project '{self._project_name}' not found for owner '{self._owner_username}'"
+        )
 
     # This will fetch app_id of app in current project
     @property

--- a/domino/domino.py
+++ b/domino/domino.py
@@ -1332,7 +1332,7 @@ class Domino:
         return self._get(url)
 
     def _dataset_remove(self, dataset_id):
-        if dataset_id in self.datasets_ids(self.project_id):
+        if dataset_id not in self.datasets_ids(self.project_id):
             raise exceptions.DatasetNotFoundException(
                 f"Dataset with id {dataset_id} does not exist"
             )


### PR DESCRIPTION
## Bug Fixes: SDK Correctness and Error Handling                                                                         
                                         
  ### Summary                                                                                                              
   
  - Fixed inverted guard condition in `_dataset_remove()` that raised on valid datasets and silently deleted invalid ones  
  - Wired `datasets_remove()` through `_dataset_remove()` so the existence check is actually enforced; added return value
  - `runs_start()` and `job_start()` now re-raise `ReloginRequiredException` instead of swallowing it and returning `None` 
  - `project_id` property now raises `ProjectNotFoundException` instead of silently returning `None` when the API response 
  is missing the `id` key
  - Replaced bare `except:` in `datasets.py` upload session with `except Exception` so `KeyboardInterrupt`/`SystemExit` are
   no longer swallowed                                                                                                     
  - `trigger_alert()` in `_custom_metrics.py` no longer sends `targetRange: {condition: null}` when no condition is
  provided                                                                                                                 
                                                            
  ### Changed Files                                                                                                        
   
  | File | Change |                                                                                                        
  |------|--------|                                         
  | `domino/domino.py` | Bugs 1, 2, 3, 4 |
  | `domino/datasets.py` | Bug 5 |
  | `domino/_custom_metrics.py` | Bug 6 |
                                                                                                                           
  ### Commits
                                                                                                                           
  | Commit | Description |                                  
  |--------|-------------|
  | `11afea3` | fix: invert guard condition in `_dataset_remove()` |
  | `69e578a` | fix: wire `datasets_remove()` through `_dataset_remove()` and return responses |
  | `12985f2` | fix: re-raise `ReloginRequiredException` in `runs_start()` and `job_start()` |                             
  | `db32ee9` | fix: raise `ProjectNotFoundException` when `project_id` key missing from response |
  | `bb8e7ba` | fix: replace bare `except` with `except Exception` in datasets upload session |                            
  | `de76a44` | fix: only include `targetRange` in `trigger_alert()` payload when condition is set |
                                                                                                                           
  ### Test Plan                                             
                                                                                                                           
  - [ ] `pytest tests/test_datasets.py` — existing dataset tests pass
  - [ ] `pytest tests/test_jobs.py` — existing job tests pass
  - [ ] `pytest tests/` — full suite passes
  - [ ] Manually verify `datasets_remove()` raises `DatasetNotFoundException` for an unknown dataset ID                    
  - [ ] Manually verify `runs_start()` raises `ReloginRequiredException` on auth failure (not silent `None`)
                                                                                                                           
  ### Notes                                                 

  - Bug 1 + Bug 2 are tightly coupled — the guard fix in Bug 1 was dead code until Bug 2 wired `datasets_remove()` to      
  actually call `_dataset_remove()`
  - The `trigger_alert()` fix aligns the hand-rolled client with the auto-generated client's payload shape                 
  - No breaking changes to any public API signatures