### PR TITLE
Change typing-extensions requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "beautifulsoup4~=4.11",
         "polling2~=0.5.0",
         "urllib3>=1.26.19,<3",
-        "typing-extensions~=4.13.0",
+        "typing-extensions~=4.13",
         "frozendict~=2.3",
         "python-dateutil~=2.8.2",
         "retry==0.9.2",


### PR DESCRIPTION
### What issue does this pull request solve?

We haven't changed everything we need to to make versions of `typing-extensions` past 4.13.0 work correctly.

### What is the solution?

Change the requirement in setup.py as well as requirements.txt.

### Testing

I have not tested this change.

- [ ] Unit test(s)

### Pull Request Reminders

- [ ] Has the [changelog](https://github.com/dominodatalab/python-domino/blob/master/CHANGELOG.md) been updated
- [ ] Has relevant documentation been updated?
- [ ] Does the code follow [Python Style Guide] (https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
- [ ] Are the existing unit tests still passing?
- [ ] Have new unit tests been added to cover any changes to the code?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
